### PR TITLE
Optional flag to tell Dotenv not to throw an InvalidArgumentException on load

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -9,10 +9,14 @@ class Dotenv
     /**
      * Load `.env` file in given directory
      */
-    public static function load($path, $file = '.env')
+    public static function load($path, $file = '.env', $failSilent = false)
     {
         $filePath = rtrim($path, '/') . '/' . $file;
         if(!file_exists($filePath)) {
+            if($failSilent) {
+                return;
+            }
+
             throw new \InvalidArgumentException("Dotenv: Environment file .env not found. Create file with your environment settings at " . $filePath);
         }
 

--- a/tests/Dotenv/Dotenv.php
+++ b/tests/Dotenv/Dotenv.php
@@ -70,5 +70,21 @@ class DotenvTest extends \PHPUnit_Framework_TestCase
         Dotenv::load(dirname(__DIR__) . '/fixtures');
         $res = Dotenv::required(array('FOOX', 'NOPE'));
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Environment file .env not found.
+     */
+    public function testDotenvNotFoundThrowsInvalidArgumentException()
+    {
+        Dotenv::load(dirname(__DIR__) . '/badpath');
+    }
+
+    public function testDotenvNotFoundFailsGracefullyWithOptionFlag()
+    {
+        Dotenv::load(dirname(__DIR__) . '/badpath', '.env', true);
+
+        $this->assertFalse(is_file(dirname(__DIR__) . '/badpath/.env'));
+    }
 }
 


### PR DESCRIPTION
If one machine has environment variables for an application set in something like `~/.zprofile` or an upstart script as part of a build process, but in other environments a `.env` file is needed, it may be useful to instruct `Dotenv::load` to fail silently if an `.env` file is not found.
