### PR TITLE
Defaults non-string values for $file back to '.env'

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -11,6 +11,10 @@ class Dotenv
      */
     public static function load($path, $file = '.env')
     {
+        if(!is_string($file)) {
+            $file = '.env';
+        }
+
         $filePath = rtrim($path, '/') . '/' . $file;
         if(!file_exists($filePath)) {
             throw new \InvalidArgumentException("Dotenv: Environment file .env not found. Create file with your environment settings at " . $filePath);

--- a/tests/Dotenv/Dotenv.php
+++ b/tests/Dotenv/Dotenv.php
@@ -70,5 +70,12 @@ class DotenvTest extends \PHPUnit_Framework_TestCase
         Dotenv::load(dirname(__DIR__) . '/fixtures');
         $res = Dotenv::required(array('FOOX', 'NOPE'));
     }
+
+    public function testDotenvNullFileArgumentUsesDefault()
+    {
+        Dotenv::load(dirname(__DIR__) . '/fixtures', null);
+
+        $this->assertEquals('bar', getenv('FOO'));
+    }
 }
 


### PR DESCRIPTION
With an additional, optional argument added in vlucas/phpdotenv#6, allowing `null` or other non-string values for `$file` may be useful. If a non-string value is provided, `$file` will be set back to `".env"`.
