### PR TITLE
Don't overwrite existing environment variables.

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -34,10 +34,14 @@ class Dotenv
                 // Remove whitespaces around key & value
                 list( $key, $val ) = array_map( 'trim', explode('=', $line, 2) );
 
-                putenv("$key=$val");
-                // Set PHP superglobals
-                $_ENV[$key] = $val;
-                $_SERVER[$key] = $val;
+                // Don't overwrite existing environment variables.
+                // Ruby's dotenv does this with `ENV[key] ||= value`.
+                if (getenv($key) === false) {
+                    putenv("$key=$val");
+                    // Set PHP superglobals
+                    $_ENV[$key] = $val;
+                    $_SERVER[$key] = $val;
+                }
             }
         }
     }

--- a/tests/Dotenv/Dotenv.php
+++ b/tests/Dotenv/Dotenv.php
@@ -87,5 +87,12 @@ class DotenvTest extends \PHPUnit_Framework_TestCase
         Dotenv::load(dirname(__DIR__) . '/fixtures', 'quoted.env');
         $this->assertTrue(isset($_ENV['QWHITESPACE']));
     }
+
+    public function testDotenvDoesNotOverwriteEnv()
+    {
+        putenv('QFOO=external');
+        Dotenv::load(dirname(__DIR__) . '/fixtures', 'quoted.env');
+        $this->assertEquals('external', getenv('QFOO'));
+    }
 }
 


### PR DESCRIPTION
Ruby's dotenv does this with `ENV[key] ||= value`.

The point of dotenv / phpdotenv is to enable twelve-factor style configuration
via environment, so it's important to be able to override these `.env` files
with external environment variables.
