### PR TITLE
Change file_exists to is_readable

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -16,10 +16,10 @@ class Dotenv
         }
 
         $filePath = rtrim($path, '/') . '/' . $file;
-        if (!file_exists($filePath) || !is_file($filePath)) {
+        if (!is_readable($filePath) || !is_file($filePath)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Dotenv: Environment file .env not found. " .
+                    "Dotenv: Environment file .env not found or not readable. " .
                     "Create file with your environment settings at %s",
                     $filePath
                 )


### PR DESCRIPTION
Using `is_readable` is a more comprehensive check since it doesn't really matter if the file exists if it's not also readable. Modified the error message to reflect the other possibility as well.
