### PR TITLE
Add space between method name and brace

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -15,7 +15,7 @@ class Dotenv
     /**
      * Load `.env` file in given directory
      */
-    public static function load($path, $file = '.env')
+    public static function load ($path, $file = '.env')
     {
         if (!is_string($file)) {
             $file = '.env';


### PR DESCRIPTION
Just for consistency with the rest of the functions.
