### PR TITLE
Removed derp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "vlucas/phpdotenv",
-    "version": "1.0.6",
     "type": "library",
     "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
     "keywords": ["env", "dotenv", "environment"],


### PR DESCRIPTION
The version should not be specified in the composer.json file. That's what tags are for. Packagist will infact ignore these and specifying versions like this could even cause issues.
