### PR TITLE
Enhancement for variables check

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -92,13 +92,14 @@ class Dotenv
 
         foreach ($environmentVariables as $environmentVariable) {
             $value = self::findEnvironmentVariable($environmentVariable);
-            if (empty($value)) {
-                $missingEnvironmentVariables[] = $environmentVariable;
-            } elseif ($allowedValues) {
+            // check allowed values first, we may allow eg. "0"
+            if ($allowedValues) {
                 if (!in_array($value, $allowedValues)) {
                     // may differentiate in the future, but for now this does the job
                     $missingEnvironmentVariables[] = $environmentVariable;
                 }
+            } elseif (empty($value)) {
+                $missingEnvironmentVariables[] = $environmentVariable;
             }
         }
 


### PR DESCRIPTION
As mentioned in the comment, we should check allowed values first, because we may allow eg. "0" which is `empty` in PHP.
