### PR TITLE
Parse line breaks

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -130,6 +130,7 @@ class Dotenv
     {
         list($name, $value) = static::splitCompoundStringIntoParts($name, $value);
         $name  = static::sanitiseVariableName($name);
+        $value = static::parseLineBreaks($value);
         $value = static::sanitiseVariableValue($value);
         $value = static::resolveNestedVariables($value);
 
@@ -221,6 +222,20 @@ class Dotenv
             );
         }
 
+        return $value;
+    }
+
+    /**
+     * Look for escaped line breaks \n and make them literal line breaks
+     *
+     * @param $value
+     * @return mixed
+     */
+    protected static function parseLineBreaks($value)
+    {
+        if (strpos($value, '\n') !== false || strpos($value, '\r') !== false) {
+            $value = str_replace(array('\n', '\r'), array("\n", "\r"), $value);
+        }
         return $value;
     }
 

--- a/tests/Dotenv/Dotenv.php
+++ b/tests/Dotenv/Dotenv.php
@@ -153,4 +153,26 @@ class DotenvTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('22222:22#2^{', getenv('SPVAR4'));
         $this->assertEquals("test some escaped characters like a quote \\' or maybe a backslash \\\\", getenv('SPVAR5'));
     }
+
+    public function testDotenvParsesLineBreaks()
+    {
+        Dotenv::load(dirname(__DIR__) . '/fixtures', 'linebreaks.env');
+
+        $expected = <<<EOF
+awesome
+multiline
+value
+EOF;
+        $this->assertEquals($expected, getenv('LINEB1'));
+        $this->assertEquals($expected, getenv('LINEB2'));
+        $this->assertEquals($expected, getenv('LINEB3'));
+
+        $lineB2 = <<<EOF
+awesome
+crazy
+multiline
+value
+EOF;
+        $this->assertEquals($lineB2, getenv('LINEB4'));
+    }
 }

--- a/tests/fixtures/linebreaks.env
+++ b/tests/fixtures/linebreaks.env
@@ -1,0 +1,5 @@
+LINEB1='awesome\nmultiline\nvalue'
+LINEB2="awesome\nmultiline\nvalue"
+LINEB3=awesome\nmultiline\nvalue
+LINEBVAR=crazy
+LINEB4=awesome\n{$LINEBVAR}\nmultiline\nvalue


### PR DESCRIPTION
Converts escaped line breaks and makes them literal line breaks. Useful things like adding public or private keys to environment variables. 