### PR TITLE
Also generate SYMFONY__* env vars

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -73,8 +73,9 @@ class Dotenv
         }
 
         putenv("$name=$value");
-        $_ENV[$name] = $value;
-        $_SERVER[$name] = $value;
+        putenv("SYMFONY__$name=$value");
+        $_ENV[$name] = $_ENV["SYMFONY__$name"] = $value;
+        $_SERVER[$name] = $_SERVER["SYMFONY__$name"] = $value;
     }
 
     /**


### PR DESCRIPTION
Allow Symfony to use generated env variables by prefixing them with "SYMFONY__". 
See [Symfony docs](http://symfony.com/doc/current/cookbook/configuration/external_parameters.html).