### PR TITLE
Add function to expose current status of the $immutable variable

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -244,6 +244,15 @@ class Dotenv
     }
 
     /**
+     * Check Dotenv immutable status.
+     * @return bool
+     */
+    public static function isImmutable()
+    {
+        return static::$immutable;
+    }
+
+    /**
      * Make Dotenv immutable. This means that once set, an environment variable cannot be overridden.
      */
     public static function makeImmutable()

--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -244,7 +244,7 @@ class Dotenv
     }
 
     /**
-     * Check Dotenv immutable status.
+     * Check Dotenv immutable status. Returns true if immutable, false if mutable.
      * @return bool
      */
     public static function isImmutable()

--- a/tests/Dotenv/Dotenv.php
+++ b/tests/Dotenv/Dotenv.php
@@ -153,4 +153,11 @@ class DotenvTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('22222:22#2^{', getenv('SPVAR4'));
         $this->assertEquals("test some escaped characters like a quote \\' or maybe a backslash \\\\", getenv('SPVAR5'));
     }
+
+    public function testDotenvImmutableStatus()
+    {
+        $this->assertTrue( Dotenv::isImmutable() );
+        Dotenv::makeMutable();
+        $this->assertFalse( Dotenv::isImmutable() );
+    }
 }

--- a/tests/Dotenv/Dotenv.php
+++ b/tests/Dotenv/Dotenv.php
@@ -156,6 +156,7 @@ class DotenvTest extends \PHPUnit_Framework_TestCase
 
     public function testDotenvImmutableStatus()
     {
+        Dotenv::makeImmutable();
         $this->assertTrue( Dotenv::isImmutable() );
         Dotenv::makeMutable();
         $this->assertFalse( Dotenv::isImmutable() );


### PR DESCRIPTION
There are functions to change between mutable and immutable, but due to the `$immutable` variable being a `protected` member it is difficult to get the current status.

I have added a function that simply returns the `$immutable` variable, as well as tests to ensure it works as expected.