### PR TITLE
Add .gitattributes file to streamline install as dependency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
As [discussed in this thread](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production) and [recommended by The League](http://thephpleague.com/#quality) it's possible to automatically exclude files and directories from a release package on GitHub. This results in those files and directories being excluded when the project is downloaded by composer as a dependency, speeding up the install and not wasting the user's time and disk space.

Here's one for Dotenv, using [laravel/framework's .gitattributes file](https://github.com/laravel/framework/blob/5.0/.gitattributes) as an example.