### PR TITLE
In PHP value "0" is false

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -161,7 +161,7 @@ class Dotenv
     protected static function sanitiseVariableValue($value)
     {
         $value = trim($value);
-        if ($value === null) return '';
+        if (strlen($value) == 0) return '';
         if (strpbrk($value[0], '"\'') !== false) { // value starts with a quote
             $quote = $value[0];
             $regexPattern = sprintf('/^

--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -161,7 +161,7 @@ class Dotenv
     protected static function sanitiseVariableValue($value)
     {
         $value = trim($value);
-        if (!$value) return '';
+        if ($value === null) return '';
         if (strpbrk($value[0], '"\'') !== false) { // value starts with a quote
             $quote = $value[0];
             $regexPattern = sprintf('/^


### PR DESCRIPTION
In PHP if `$value = "0"` then stetmentes like `if (!$value)` will be `true`, which might not be an expected behavior in this case.
If you check Ruby Dotenv code, same statement works pretty well and that's because in Ruby value `0` is equivalent to `true` (unlike most other languages).