### PR TITLE
prefix json fixture variables with J

### DIFF
--- a/src/Variable/VariableFactory.php
+++ b/src/Variable/VariableFactory.php
@@ -66,7 +66,7 @@ class VariableFactory
     }
 
     /**
-     * Look for `{$varname}` patterns in the variable value and replace with an existing
+     * Look for `${varname}` patterns in the variable value and replace with an existing
      * environment variable.
      *
      * @param string $name

--- a/tests/Dotenv/DotenvJsonTest.php
+++ b/tests/Dotenv/DotenvJsonTest.php
@@ -19,30 +19,30 @@ class DotenvJsonTest extends \PHPUnit_Framework_TestCase
     public function testDotenvLoadsEnvironmentVars()
     {
         $this->dotenv->load($this->fixturesFolder);
-        $this->assertEquals('bar', getenv('PE_FOO'));
-        $this->assertEquals('baz', getenv('PE_BAR'));
+        $this->assertEquals('bar', getenv('JE_FOO'));
+        $this->assertEquals('baz', getenv('JE_BAR'));
     }
 
     public function testDotenvRequiredStringEnvironmentVars()
     {
         $this->dotenv->load($this->fixturesFolder, '.env.json');
-        $this->dotenv->required('PE_FOO');
+        $this->dotenv->required('JE_FOO');
         $this->assertTrue(true); // anything wrong an an exception will be thrown
     }
 
     public function testDotenvRequiredArrayEnvironmentVars()
     {
         $this->dotenv->load($this->fixturesFolder, '.env.json');
-        $this->dotenv->required(array('PE_FOO', 'PE_BAR'));
+        $this->dotenv->required(array('JE_FOO', 'JE_BAR'));
         $this->assertTrue(true); // anything wrong an an exception will be thrown
     }
 
     public function testDotenvNestedEnvironmentVars()
     {
         $this->dotenv->load($this->fixturesFolder, 'nested.env.json');
-        $this->assertEquals('{$PNVAR1} {$PNVAR2}', $_ENV['PNVAR3']); // not resolved
-        $this->assertEquals('Hello World!', $_ENV['PNVAR4']);
-        $this->assertEquals('$PNVAR1 {PNVAR2}', $_ENV['PNVAR5']); // not resolved
+        $this->assertEquals('{$JNVAR1} {$JNVAR2}', $_ENV['JNVAR3']); // not resolved
+        $this->assertEquals('Hello World!', $_ENV['JNVAR4']);
+        $this->assertEquals('$JNVAR1 {JNVAR2}', $_ENV['JNVAR5']); // not resolved
     }
 
     public function testDotenvIgnoresEmptyFile()
@@ -61,14 +61,14 @@ class DotenvJsonTest extends \PHPUnit_Framework_TestCase
     {
         $this->dotenv->load($this->fixturesFolder, 'stringvalues.env.json');
         $assertions = array(
-            'PS_INT'    => '1',
-            'PS_FLOAT'  => '20.5',
-            'PS_STRING' => 'string',
-            'PS_FALSE'  => 'false',
-            'PS_TRUE'  =>  'true',
-            'PS_ARRAY'  => '',
-            'PS_HASH'   => "",
-            'PS_OBJECT' => '',
+            'JS_INT'    => '1',
+            'JS_FLOAT'  => '20.5',
+            'JS_STRING' => 'string',
+            'JS_FALSE'  => 'false',
+            'JS_TRUE'  =>  'true',
+            'JS_ARRAY'  => '',
+            'JS_HASH'   => "",
+            'JS_OBJECT' => '',
         );
         foreach ($assertions as $k => $v) {
             $this->assertEquals($v, $_ENV[$k]);

--- a/tests/fixtures/json/.env.json
+++ b/tests/fixtures/json/.env.json
@@ -1,4 +1,4 @@
 {
-	"PE_FOO": "bar",
-	"PE_BAR": "baz"
+	"JE_FOO": "bar",
+	"JE_BAR": "baz"
 }

--- a/tests/fixtures/json/nested.env.json
+++ b/tests/fixtures/json/nested.env.json
@@ -1,7 +1,7 @@
 {
-	"PNVAR1": "Hello",
-	"PNVAR2": "World!",
-	"PNVAR3": "{$PNVAR1} {$PNVAR2}",
-	"PNVAR4": "${PNVAR1} ${PNVAR2}",
-	"PNVAR5": "$PNVAR1 {PNVAR2}"
+	"JNVAR1": "Hello",
+	"JNVAR2": "World!",
+	"JNVAR3": "{$JNVAR1} {$JNVAR2}",
+	"JNVAR4": "${JNVAR1} ${JNVAR2}",
+	"JNVAR5": "$JNVAR1 {JNVAR2}"
 }

--- a/tests/fixtures/json/stringvalues.env.json
+++ b/tests/fixtures/json/stringvalues.env.json
@@ -1,16 +1,16 @@
 {
-	"PS_INT": 1,
-	"PS_FLOAT": 20.5,
-	"PS_STRING": "string",
-	"PS_FALSE": false,
-	"PS_TRUE": true,
-	"PS_ARRAY": [
+	"JS_INT": 1,
+	"JS_FLOAT": 20.5,
+	"JS_STRING": "string",
+	"JS_FALSE": false,
+	"JS_TRUE": true,
+	"JS_ARRAY": [
 		1,
 		2,
 		3
 	],
-	"PS_HASH": {
+	"JS_HASH": {
 		"key": "value"
 	},
-	"PS_OBJECT": {}
+	"JS_OBJECT": {}
 }


### PR DESCRIPTION
The json fixture variable names is same with php fixture variable names. After DotenvJsonTest, the variables have been set and when loading, the default $immutable is true. So even if php fixtures don't be loaded, the test can pass. 