### PR TITLE
add composer/installers to allow the option to customize where the li…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9"
+        "php": ">=5.3.9",
+        "composer/installers": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
…brary is loaded

I have a WordPress application where I am going to need to specifically install this library in a separate directory and include it earlier than it would if it were in my default vendor directory.  I'm already using the vendor directory in a separate location (`mu-plugins` with the composer autoloader) which runs much later than I need the dotenv code to run.

This shouldn't impact anything in your app.