### PR TITLE
Move loader creation to the constructor

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -26,6 +26,7 @@ class Dotenv
     public function __construct($path, $file = '.env')
     {
         $this->filePath = $this->getFilePath($path, $file);
+        $this->loader = new Loader($this->filePath, $immutable = true);
     }
 
     /**
@@ -35,8 +36,6 @@ class Dotenv
      */
     public function load()
     {
-        $this->loader = new Loader($this->filePath, $immutable = true);
-
         return $this->loader->load();
     }
 

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -271,4 +271,14 @@ class DotenvTest extends \PHPUnit_Framework_TestCase
         $dotenv->load();
         $dotenv->required('ASSERTVAR3')->notEmpty();
     }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage One or more environment variables failed assertions: foo is missing
+     */
+    public function testDotenvValidateRequiredWithoutLoading()
+    {
+        $dotenv = new Dotenv($this->fixturesFolder, 'assertions.env');
+        $dotenv->required('foo');
+    }
 }


### PR DESCRIPTION
This allow the use of `$dotenv->required` to validate environment variables without loading without explicitly loading a .env file. Unless i'm horribly mistaken, this should fix #101 and allow validation environment variables even if we don't use a .env file.