### PR TITLE
Fix load being called after overload. Add test case to cover.

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -36,6 +36,8 @@ class Dotenv
      */
     public function load()
     {
+        $this->loader = new Loader($this->filePath, $immutable = true);
+
         return $this->loader->load();
     }
 

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -188,6 +188,30 @@ class DotenvTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('true', getenv('IMMUTABLE'));
     }
 
+    public function testDotenvLoadAfterOverload()
+    {
+        putenv('IMMUTABLE=true');
+        $dotenv = new Dotenv($this->fixturesFolder, 'immutable.env');
+        $dotenv->overload();
+        $this->assertEquals('false', getenv('IMMUTABLE'));
+
+        putenv('IMMUTABLE=true');
+        $dotenv->load();
+        $this->assertEquals('true', getenv('IMMUTABLE'));
+    }
+
+    public function testDotenvOverloadAfterLoad()
+    {
+        putenv('IMMUTABLE=true');
+        $dotenv = new Dotenv($this->fixturesFolder, 'immutable.env');
+        $dotenv->load();
+        $this->assertEquals('true', getenv('IMMUTABLE'));
+
+        putenv('IMMUTABLE=true');
+        $dotenv->overload();
+        $this->assertEquals('false', getenv('IMMUTABLE'));
+    }
+
     public function testDotenvOverloadDoesOverwriteEnv()
     {
         $dotenv = new Dotenv($this->fixturesFolder, 'mutable.env');


### PR DESCRIPTION
This should address https://github.com/vlucas/phpdotenv/pull/102#discussion-diff-34529622. I added test case covering `load` after `overload` and vice versa.