### PR TITLE
Fix: Do not declare fields dynamically

### DIFF
--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -4,6 +4,16 @@ use Dotenv\Dotenv;
 
 class DotenvTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var string
+     */
+    private $fixturesFolder;
+
+    /**
+     * @var string
+     */
+    private $fixturesFolderWrong;
+
     public function setUp()
     {
         $this->fixturesFolder = dirname(__DIR__).'/fixtures/env';


### PR DESCRIPTION
This PR

* [x] declares fields in a test