### PR TITLE
Check if `putenv` exists before use

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -340,9 +340,11 @@ class Loader
         if (function_exists('apache_getenv') && function_exists('apache_setenv') && apache_getenv($name)) {
             apache_setenv($name, $value);
         }
-
-        putenv("$name=$value");
-
+        
+        if (function_exists('putenv')){
+            putenv("$name=$value");
+        }
+        
         $_ENV[$name] = $value;
         $_SERVER[$name] = $value;
     }
@@ -369,8 +371,10 @@ class Loader
         if ($this->immutable) {
             return;
         }
-
-        putenv($name);
+        
+        if (function_exists('putenv')){
+            putenv($name);
+        }
 
         unset($_ENV[$name], $_SERVER[$name]);
     }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -29,6 +29,13 @@ class Loader
     protected $immutable;
 
     /**
+     * Is `putenv` allowed?
+     *
+     * @var bool
+     */
+    protected $putenvAllowed;
+
+    /**
      * Create a new loader instance.
      *
      * @param string $filePath
@@ -40,6 +47,7 @@ class Loader
     {
         $this->filePath = $filePath;
         $this->immutable = $immutable;
+        $this->putenvAllowed = function_exists('putenv');
     }
 
     /**
@@ -341,7 +349,7 @@ class Loader
             apache_setenv($name, $value);
         }
         
-        if (function_exists('putenv')){
+        if ($this->putenvAllowed){
             putenv("$name=$value");
         }
         
@@ -372,7 +380,7 @@ class Loader
             return;
         }
         
-        if (function_exists('putenv')){
+        if ($this->putenvAllowed){
             putenv($name);
         }
 


### PR DESCRIPTION
Some platforms disable `putenv` function for security reasons. To make phpdotenv function well on those platforms, we need to check if `putenv` exists before calling it.