### PR TITLE
Must execute load() before the required()

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ If any ENV vars are missing, Dotenv will throw a `RuntimeException` like this:
 One or more environment variables failed assertions: DATABASE_DSN is missing
 ```
 
+> **NOTICE**: For the `DotEnv:load()` must be executed before
+
 ### Empty Variables
 
 Beyond simply requiring a variable to be set, you might also need to ensure the


### PR DESCRIPTION
I took a while to understand why the required env was not being considered/loaded.
I actually needed to look at how the code worked before making it work.

I'm suggesting a simple doc change.
However it would be possible to force load() when executing required()

What you guys think?
Did I missed something?