### PR TITLE
Switch to new recommended syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0"
+        "phpunit/phpunit": "^4.8 || ^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Composer now recommends using `||` instead of a single `|`.

https://getcomposer.org/doc/articles/versions.md#range
