### PR TITLE
Remove composer defaults

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,7 @@
 {
     "name": "vlucas/phpdotenv",
-    "type": "library",
     "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
     "keywords": ["env", "dotenv", "environment"],
-    "homepage": "http://github.com/vlucas/phpdotenv",
     "license" : "BSD-3-Clause-Attribution",
     "authors" : [
         {


### PR DESCRIPTION
Library and the GitHub link will be used by default by Packagist.