### PR TITLE
if Loader is not immutable, override Apache env vars

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -336,7 +336,9 @@ class Loader
         }
 
         if (function_exists('apache_setenv')) {
-            if (function_exists('apache_getenv') && apache_getenv($name)) apache_setenv($name, $value);
+            if (function_exists('apache_getenv') && apache_getenv($name)) {
+                apache_setenv($name, $value);
+            }
         }
 
         putenv("$name=$value");

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -335,6 +335,10 @@ class Loader
             return;
         }
 
+        if (function_exists('apache_setenv')) {
+            if (function_exists('apache_getenv') && apache_getenv($name)) apache_setenv($name, $value);
+        }
+
         putenv("$name=$value");
 
         $_ENV[$name] = $value;

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -335,7 +335,9 @@ class Loader
             return;
         }
 
-        if (function_exists('apache_setenv') && function_exists('apache_getenv') && apache_getenv($name)) {
+        // If PHP is running as an Apache module and an existing
+        // Apache environment variable exists, overwrite it
+        if (function_exists('apache_setenv') && apache_getenv($name)) {
             apache_setenv($name, $value);
         }
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -335,10 +335,8 @@ class Loader
             return;
         }
 
-        if (function_exists('apache_setenv')) {
-            if (function_exists('apache_getenv') && apache_getenv($name)) {
-                apache_setenv($name, $value);
-            }
+        if (function_exists('apache_setenv') && function_exists('apache_getenv') && apache_getenv($name)) {
+            apache_setenv($name, $value);
         }
 
         putenv("$name=$value");


### PR DESCRIPTION
This PR fixes https://github.com/vlucas/phpdotenv/issues/39.

I have not written additional tests due to the added complexity of introducing Apache as a dependency of the test suite, but I would be happy to provide some if you would like.