### PR TITLE
Falsey value for 'false'

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -223,6 +223,10 @@ class Loader
             $parts = explode(' #', $value, 2);
             $value = trim($parts[0]);
 
+			if ('false' == $value) { # getenv() returns a string, 'false' is not falsey
+				$value = false;
+			}
+
             // Unquoted values cannot contain whitespace
             if (preg_match('/\s+/', $value) > 0) {
                 throw new InvalidFileException('Dotenv values containing spaces must be surrounded by quotes.');

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -196,41 +196,41 @@ class DotenvTest extends PHPUnit_Framework_TestCase
 
     public function testDotenvLoadDoesNotOverwriteEnv()
     {
-        putenv('IMMUTABLE=true');
+        putenv('VALUE=set_by_environment');
         $dotenv = new Dotenv($this->fixturesFolder, 'immutable.env');
         $dotenv->load();
-        $this->assertSame('true', getenv('IMMUTABLE'));
+        $this->assertSame('set_by_environment', getenv('VALUE'));
     }
 
     public function testDotenvLoadAfterOverload()
     {
-        putenv('IMMUTABLE=true');
+        putenv('VALUE=set_by_environment');
         $dotenv = new Dotenv($this->fixturesFolder, 'immutable.env');
         $dotenv->overload();
-        $this->assertSame('false', getenv('IMMUTABLE'));
+        $this->assertSame('set_by_file', getenv('VALUE'));
 
-        putenv('IMMUTABLE=true');
+        putenv('VALUE=set_by_environment');
         $dotenv->load();
-        $this->assertSame('true', getenv('IMMUTABLE'));
+        $this->assertSame('set_by_environment', getenv('VALUE'));
     }
 
     public function testDotenvOverloadAfterLoad()
     {
-        putenv('IMMUTABLE=true');
+        putenv('VALUE=set_by_environment');
         $dotenv = new Dotenv($this->fixturesFolder, 'immutable.env');
         $dotenv->load();
-        $this->assertSame('true', getenv('IMMUTABLE'));
+        $this->assertSame('set_by_environment', getenv('VALUE'));
 
-        putenv('IMMUTABLE=true');
+        putenv('VALUE=set_by_environment');
         $dotenv->overload();
-        $this->assertSame('false', getenv('IMMUTABLE'));
+        $this->assertSame('set_by_file', getenv('VALUE'));
     }
 
     public function testDotenvOverloadDoesOverwriteEnv()
     {
         $dotenv = new Dotenv($this->fixturesFolder, 'mutable.env');
         $dotenv->overload();
-        $this->assertSame('true', getenv('MUTABLE'));
+        $this->assertSame('set_by_file', getenv('MUTABLE'));
     }
 
     public function testDotenvAllowsSpecialCharacters()

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -327,4 +327,37 @@ class DotenvTest extends PHPUnit_Framework_TestCase
         $dotenv->required('REQUIRED_VAR')->notEmpty();
         $this->assertTrue(true);
     }
+    public function testDotenvFalseyValuesAreFalsey()
+    {
+        $dotenv = new Dotenv($this->fixturesFolder, 'falsey.env');
+        $dotenv->load();
+        $this->assertFalse(!!getenv('FALSEY_BECAUSE_EMPTY'));
+        $this->assertFalse(!!getenv('FALSEY_BECAUSE_ZERO'));
+        $this->assertFalse(!!getenv('LOWERCASE_FALSE'));
+    }
+    public function testDotenvTruthyValuesAreTruthy()
+    {
+        $dotenv = new Dotenv($this->fixturesFolder, 'falsey.env');
+        $dotenv->load();
+
+        $this->assertTrue(!!getenv('CAPITALISED_FALSE'));
+        $this->assertTrue(!!getenv('UPPERCASE_FALSE'));
+        $this->assertTrue(!!getenv('FUNKY_CASE_FALSE'));
+
+        $this->assertTrue(!!getenv('LOWERCASE_TRUE'));
+        $this->assertTrue(!!getenv('CAPITALISED_TRUE'));
+        $this->assertTrue(!!getenv('UPPERCASE_TRUE'));
+        $this->assertTrue(!!getenv('FUNKY_CASE_TRUE'));
+
+        $this->assertTrue(!!getenv('LOWERCASE_NULL'));
+        $this->assertTrue(!!getenv('CAPITALISED_NULL'));
+        $this->assertTrue(!!getenv('UPPERCASE_NULL'));
+        $this->assertTrue(!!getenv('FUNKY_CASE_NULL'));
+
+        $this->assertTrue(!!getenv('GIBBERISH'));
+        $this->assertTrue(!!getenv('NONZERO_NUMBER'));
+    }
+
+
+
 }

--- a/tests/fixtures/env/falsey.env
+++ b/tests/fixtures/env/falsey.env
@@ -1,0 +1,23 @@
+# Those are tests to see what (unquoted) values will become falsey
+# If your editor recognises only numbers, lowercase 'true' and 'false' as special values then we're on the same page here.
+
+FALSEY_BECAUSE_EMPTY=
+FALSEY_BECAUSE_ZERO=0
+
+LOWERCASE_FALSE=false # This should be the last falsey value here
+CAPITALISED_FALSE=False
+UPPERCASE_FALSE=FALSE
+FUNKY_CASE_FALSE=FaLsE
+
+LOWERCASE_NULL=null
+CAPITALISED_NULL=Null
+UPPERCASE_NULL=Null
+FUNKY_CASE_NULL=nULl
+
+LOWERCASE_TRUE=true # well, it's truthy either way - both as a string and as a value
+CAPITALISED_TRUE=True
+UPPERCASE_TRUE=TRUE
+FUNKY_CASE_TRUE=tRue
+
+GIBBERISH=gibBERIsh
+NONZERO_NUMBER=-3

--- a/tests/fixtures/env/immutable.env
+++ b/tests/fixtures/env/immutable.env
@@ -1,1 +1,1 @@
-IMMUTABLE=false
+VALUE=set_by_file

--- a/tests/fixtures/env/mutable.env
+++ b/tests/fixtures/env/mutable.env
@@ -1,1 +1,1 @@
-MUTABLE=true
+MUTABLE=set_by_file


### PR DESCRIPTION
As of now, there is a following gotcha: `THIS_IS_FALSE=false ` results in `getenv('THIS_IS_FALSE')` returning literal 'false', which is truthy.

That is confusing! Especially since editors recognise .env syntax and highlight that 'false' as a recognised value.

I suppose parsing lowercase unquoted 'false' as a falsey value is less surprizing than parsing it as a truthy one.

Alternatively, this gotcha could be mentioned in the Readme with a suggestion to use '1' and '0' instead of 'true' and 'false'.