### PR TITLE
Make it easier to swap out the loader, to allow for a custom loader

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -20,7 +20,7 @@ class Dotenv
     /**
      * The loader instance.
      *
-     * @var \Dotenv\Loader|null
+     * @var \Dotenv\LoaderInterface|null
      */
     protected $loader;
 
@@ -35,7 +35,7 @@ class Dotenv
     public function __construct($path, $file = '.env')
     {
         $this->filePath = $this->getFilePath($path, $file);
-        $this->loader = new Loader($this->filePath, true);
+        $this->loader = $this->getLoader();
     }
 
     /**
@@ -86,7 +86,7 @@ class Dotenv
      */
     protected function loadData($overload = false)
     {
-        $this->loader = new Loader($this->filePath, !$overload);
+        $this->loader = $this->getLoader(! $overload);
 
         return $this->loader->load();
     }
@@ -101,5 +101,15 @@ class Dotenv
     public function required($variable)
     {
         return new Validator((array) $variable, $this->loader);
+    }
+
+    /**
+     * @param bool $immutable
+     *
+     * @return LoaderInterface
+     */
+    protected function getLoader($immutable = true)
+    {
+        return new Loader($this->filePath, $immutable);
     }
 }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -12,7 +12,7 @@ use Dotenv\Exception\InvalidPathException;
  * - stripping comments beginning with a `#`,
  * - parsing lines that look shell variable setters, e.g `export key = value`, `key="value"`.
  */
-class Loader
+class Loader implements LoaderInterface
 {
     /**
      * The file path.

--- a/src/LoaderInterface.php
+++ b/src/LoaderInterface.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Dotenv;
+
+/**
+ * This is the loaded interface.
+ */
+interface LoaderInterface
+{
+    /**
+     * Load config data into array
+     *
+     * @return array
+     */
+    public function load();
+
+    /**
+     * Process the runtime filters.
+     *
+     * Called from the `VariableFactory`, passed as a callback in `$this->loadFromFile()`.
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return array
+     */
+    public function processFilters($name, $value);
+
+    /**
+     * Search the different places for environment variables and return first value found.
+     *
+     * @param string $name
+     *
+     * @return string|null
+     */
+    public function getEnvironmentVariable($name);
+
+    /**
+     * Set an environment variable.
+     *
+     * This is done using:
+     * - putenv,
+     * - $_ENV,
+     * - $_SERVER.
+     *
+     * The environment variable value is stripped of single and double quotes.
+     *
+     * @param string      $name
+     * @param string|null $value
+     *
+     * @return void
+     */
+    public function setEnvironmentVariable($name, $value = null);
+
+    /**
+     * Clear an environment variable.
+     *
+     * This is not (currently) used by Dotenv but is provided as a utility
+     * method for 3rd party code.
+     *
+     * This is done using:
+     * - putenv,
+     * - unset($_ENV, $_SERVER).
+     *
+     * @param string $name
+     *
+     * @see setEnvironmentVariable()
+     *
+     * @return void
+     */
+    public function clearEnvironmentVariable($name);
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -22,19 +22,19 @@ class Validator
     /**
      * The loader instance.
      *
-     * @var \Dotenv\Loader
+     * @var \Dotenv\LoaderInterface
      */
     protected $loader;
 
     /**
      * Create a new validator instance.
      *
-     * @param array          $variables
-     * @param \Dotenv\Loader $loader
+     * @param array                   $variables
+     * @param \Dotenv\LoaderInterface $loader
      *
      * @return void
      */
-    public function __construct(array $variables, Loader $loader)
+    public function __construct(array $variables, LoaderInterface $loader)
     {
         $this->variables = $variables;
         $this->loader = $loader;


### PR DESCRIPTION
Small PR which just moves the loader to a place where it can be easily overwritten to allow for custom loaders and adds a `LoadedInterface`

My particular use-case for this concerns some additional pre-processing steps necessary to allow the `.env` file to be readable, therefore requiring a custom loader with a minor addition to the existing loader, this would make it easier/cleaner to overwrite the loader in the `Dotenv` class.
