### PR TITLE
added support for null and boolean values

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -29,8 +29,6 @@ class Dotenv
      *
      * @param string $path
      * @param string $file
-     *
-     * @return void
      */
     public function __construct($path, $file = '.env')
     {

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -7,5 +7,4 @@ namespace Dotenv\Exception;
  */
 interface ExceptionInterface
 {
-    //
 }

--- a/src/Exception/InvalidCallbackException.php
+++ b/src/Exception/InvalidCallbackException.php
@@ -9,5 +9,4 @@ use InvalidArgumentException;
  */
 class InvalidCallbackException extends InvalidArgumentException implements ExceptionInterface
 {
-    //
 }

--- a/src/Exception/InvalidFileException.php
+++ b/src/Exception/InvalidFileException.php
@@ -9,5 +9,4 @@ use InvalidArgumentException;
  */
 class InvalidFileException extends InvalidArgumentException implements ExceptionInterface
 {
-    //
 }

--- a/src/Exception/InvalidPathException.php
+++ b/src/Exception/InvalidPathException.php
@@ -9,5 +9,4 @@ use InvalidArgumentException;
  */
 class InvalidPathException extends InvalidArgumentException implements ExceptionInterface
 {
-    //
 }

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -9,5 +9,4 @@ use RuntimeException;
  */
 class ValidationException extends RuntimeException implements ExceptionInterface
 {
-    //
 }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -33,8 +33,6 @@ class Loader
      *
      * @param string $filePath
      * @param bool   $immutable
-     *
-     * @return void
      */
     public function __construct($filePath, $immutable = false)
     {
@@ -66,8 +64,6 @@ class Loader
      * Ensures the given filePath is readable.
      *
      * @throws \Dotenv\Exception\InvalidPathException
-     *
-     * @return void
      */
     protected function ensureFileIsReadable()
     {
@@ -233,21 +229,21 @@ class Loader
             $v = strtolower(trim($value));
 
             switch ($v) {
-                case 'null' :
+                case 'null':
                     $value = null;
     //                die('value: '.(is_null($value) ? 'null' : 'not null'));
                     break;
 
-                case 'true' :
-                case 'yes' :
-                case 'on' :
+                case 'true':
+                case 'yes':
+                case 'on':
                     $value = true;
 
                     break;
 
-                case 'false' :
-                case 'no' :
-                case 'off' :
+                case 'false':
+                case 'no':
+                case 'off':
                     $value = false;
                     break;
             }
@@ -330,6 +326,7 @@ class Loader
                 return $_SERVER[$name];
             default:
                 $value = getenv($name);
+
                 return $value === false ? null : $value; // switch getenv default to null
         }
     }
@@ -346,8 +343,6 @@ class Loader
      *
      * @param string      $name
      * @param string|null $value
-     *
-     * @return void
      */
     public function setEnvironmentVariable($name, $value = null)
     {
@@ -386,8 +381,6 @@ class Loader
      * @param string $name
      *
      * @see setEnvironmentVariable()
-     *
-     * @return void
      */
     public function clearEnvironmentVariable($name)
     {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -194,10 +194,11 @@ class Loader
      */
     protected function sanitiseVariableValue($name, $value)
     {
-        $value = trim($value);
-        if (!$value) {
+        if (!$value || !is_string($value)) {
             return array($name, $value);
         }
+
+        $value = trim($value);
 
         if ($this->beginsWithAQuote($value)) { // value starts with a quote
             $quote = $value[0];
@@ -219,6 +220,7 @@ class Loader
             $value = preg_replace($regexPattern, '$1', $value);
             $value = str_replace("\\$quote", $quote, $value);
             $value = str_replace('\\\\', '\\', $value);
+            $value = trim($value);
         } else {
             $parts = explode(' #', $value, 2);
             $value = trim($parts[0]);
@@ -227,26 +229,28 @@ class Loader
             if (preg_match('/\s+/', $value) > 0) {
                 throw new InvalidFileException('Dotenv values containing spaces must be surrounded by quotes.');
             }
-        }
 
-        $v = strtolower(trim($value));
+            $v = strtolower(trim($value));
 
-        switch ($v) {
-            case 'null' :
-                $value = null;
-                break;
+            switch ($v) {
+                case 'null' :
+                    $value = null;
+    //                die('value: '.(is_null($value) ? 'null' : 'not null'));
+                    break;
 
-            case 'true' :
-            case 'yes' :
-            case 'on' :
-                $value = true;
-                break;
+                case 'true' :
+                case 'yes' :
+                case 'on' :
+                    $value = true;
 
-            case 'false' :
-            case 'no' :
-            case 'off' :
-                $value = false;
-                break;
+                    break;
+
+                case 'false' :
+                case 'no' :
+                case 'off' :
+                    $value = false;
+                    break;
+            }
         }
 
         return array($name, $value);

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -229,7 +229,27 @@ class Loader
             }
         }
 
-        return array($name, trim($value));
+        $v = strtolower(trim($value));
+
+        switch ($v) {
+            case 'null' :
+                $value = null;
+                break;
+
+            case 'true' :
+            case 'yes' :
+            case 'on' :
+                $value = true;
+                break;
+
+            case 'false' :
+            case 'no' :
+            case 'off' :
+                $value = false;
+                break;
+        }
+
+        return array($name, $value);
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -31,8 +31,6 @@ class Validator
      *
      * @param array          $variables
      * @param \Dotenv\Loader $loader
-     *
-     * @return void
      */
     public function __construct(array $variables, Loader $loader)
     {

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -31,7 +31,17 @@ class DotenvTest extends PHPUnit_Framework_TestCase
         $this->assertSame('bar', getenv('FOO'));
         $this->assertSame('baz', getenv('BAR'));
         $this->assertSame('with spaces', getenv('SPACED'));
+        $this->assertEmpty(getenv('EMPTY'));
+
         $this->assertEmpty(getenv('NULL'));
+
+        $this->assertEquals(1, getenv('ETRUE'));
+        $this->assertEquals(1, getenv('EYES'));
+        $this->assertEquals(1, getenv('EON'));
+
+        $this->assertEmpty(getenv('EFALSE'));
+        $this->assertEmpty(getenv('ENO'));
+        $this->assertEmpty(getenv('EOFF'));
     }
 
     public function testCommentedDotenvLoadsEnvironmentVars()
@@ -54,9 +64,18 @@ class DotenvTest extends PHPUnit_Framework_TestCase
         $this->assertSame('bar', getenv('QFOO'));
         $this->assertSame('baz', getenv('QBAR'));
         $this->assertSame('with spaces', getenv('QSPACED'));
-        $this->assertEmpty(getenv('QNULL'));
+        $this->assertEmpty(getenv('QEMPTY'));
         $this->assertSame('pgsql:host=localhost;dbname=test', getenv('QEQUALS'));
         $this->assertSame('test some escaped characters like a quote (") or maybe a backslash (\\)', getenv('QESCAPED'));
+
+        $this->assertSame('null', getenv('QNULL'));
+        $this->assertSame('true', getenv('QTRUE'));
+        $this->assertSame('yes', getenv('QYES'));
+        $this->assertSame('on', getenv('QON'));
+
+        $this->assertSame('false', getenv('QFALSE'));
+        $this->assertSame('no', getenv('QNO'));
+        $this->assertSame('off', getenv('QOFF'));
     }
 
     /**
@@ -87,6 +106,24 @@ class DotenvTest extends PHPUnit_Framework_TestCase
         $this->assertSame('baz', $_SERVER['BAR']);
         $this->assertSame('with spaces', $_SERVER['SPACED']);
         $this->assertEmpty($_SERVER['NULL']);
+
+        $this->assertSame('null', $_SERVER['QNULL']);
+
+        $this->assertTrue($_SERVER['ETRUE']);
+        $this->assertTrue($_SERVER['EYES']);
+        $this->assertTrue($_SERVER['EON']);
+
+        $this->assertFalse($_SERVER['EFALSE']);
+        $this->assertFalse($_SERVER['ENO']);
+        $this->assertFalse($_SERVER['EOFF']);
+
+        $this->assertSame('true', $_SERVER['QTRUE']);
+        $this->assertSame('yes', $_SERVER['QYES']);
+        $this->assertSame('on', $_SERVER['QON']);
+
+        $this->assertSame('false', $_SERVER['QFALSE']);
+        $this->assertSame('no', $_SERVER['QNO']);
+        $this->assertSame('off', $_SERVER['QOFF']);
     }
 
     public function testDotenvLoadsServerGlobals()
@@ -97,6 +134,24 @@ class DotenvTest extends PHPUnit_Framework_TestCase
         $this->assertSame('baz', $_ENV['BAR']);
         $this->assertSame('with spaces', $_ENV['SPACED']);
         $this->assertEmpty($_ENV['NULL']);
+
+        $this->assertSame('null', $_ENV['QNULL']);
+
+        $this->assertTrue($_ENV['ETRUE']);
+        $this->assertTrue($_ENV['EYES']);
+        $this->assertTrue($_ENV['EON']);
+
+        $this->assertFalse($_ENV['EFALSE']);
+        $this->assertFalse($_ENV['ENO']);
+        $this->assertFalse($_ENV['EOFF']);
+
+        $this->assertSame('true', $_ENV['QTRUE']);
+        $this->assertSame('yes', $_ENV['QYES']);
+        $this->assertSame('on', $_ENV['QON']);
+
+        $this->assertSame('false', $_ENV['QFALSE']);
+        $this->assertSame('no', $_ENV['QNO']);
+        $this->assertSame('off', $_ENV['QOFF']);
     }
 
     /**
@@ -207,11 +262,11 @@ class DotenvTest extends PHPUnit_Framework_TestCase
         putenv('IMMUTABLE=true');
         $dotenv = new Dotenv($this->fixturesFolder, 'immutable.env');
         $dotenv->overload();
-        $this->assertSame('false', getenv('IMMUTABLE'));
+        $this->assertEmpty(getenv('IMMUTABLE'));
 
         putenv('IMMUTABLE=true');
         $dotenv->load();
-        $this->assertSame('true', getenv('IMMUTABLE'));
+        $this->assertEquals('true', getenv('IMMUTABLE'));
     }
 
     public function testDotenvOverloadAfterLoad()
@@ -223,14 +278,14 @@ class DotenvTest extends PHPUnit_Framework_TestCase
 
         putenv('IMMUTABLE=true');
         $dotenv->overload();
-        $this->assertSame('false', getenv('IMMUTABLE'));
+        $this->assertEmpty(getenv('IMMUTABLE'));
     }
 
     public function testDotenvOverloadDoesOverwriteEnv()
     {
         $dotenv = new Dotenv($this->fixturesFolder, 'mutable.env');
         $dotenv->overload();
-        $this->assertSame('true', getenv('MUTABLE'));
+        $this->assertEquals(1, getenv('MUTABLE'));
     }
 
     public function testDotenvAllowsSpecialCharacters()

--- a/tests/Dotenv/LoaderTest.php
+++ b/tests/Dotenv/LoaderTest.php
@@ -13,10 +13,10 @@ class LoaderTest extends PHPUnit_Framework_TestCase
      * @var \Dotenv\Loader
      */
     private $mutableLoader;
-    
+
     public function setUp()
     {
-        $folder = dirname(__DIR__) . '/fixtures/env';
+        $folder = dirname(__DIR__).'/fixtures/env';
 
         // Generate a new, random keyVal.
         $this->keyVal(true);
@@ -36,8 +36,8 @@ class LoaderTest extends PHPUnit_Framework_TestCase
      * key/value pairs.
      *
      * @param bool $reset
-     *   If true, a new pair will be generated. If false, the last returned pair
-     *   will be returned.
+     *                    If true, a new pair will be generated. If false, the last returned pair
+     *                    will be returned
      *
      * @return array
      */

--- a/tests/fixtures/env/.env
+++ b/tests/fixtures/env/.env
@@ -2,4 +2,24 @@ FOO=bar
 BAR=baz
 SPACED="with spaces"
 
-NULL=
+EMPTY=
+
+NULL=null
+
+QNULL="null"
+
+ETRUE=true
+EYES=yes
+EON=on
+
+EFALSE=false
+ENO=no
+EOFF=off
+
+QTRUE="true"
+QYES="yes"
+QON="on"
+
+QFALSE="false"
+QNO="no"
+QOFF="off"

--- a/tests/fixtures/env/quoted.env
+++ b/tests/fixtures/env/quoted.env
@@ -3,7 +3,17 @@ QBAR="baz"
 QSPACED="with spaces"
 QEQUALS="pgsql:host=localhost;dbname=test"
 
-QNULL=""
+QEMPTY=""
+
+QNULL="null"
 QWHITESPACE = "no space"
 
 QESCAPED="test some escaped characters like a quote (\") or maybe a backslash (\\)"
+
+QTRUE="true"
+QYES="yes"
+QON="on"
+
+QFALSE="false"
+QNO="no"
+QOFF="off"


### PR DESCRIPTION
To specify a null value, use the keyword `null`. To specify the boolean true value, use the keywords `true`, `yes,` `on`. To specify the boolean false value, use the keywords `false`, `no`, `off`. 

The keywords must be used without quotes.

If used with quotes, the actual string will be used instead.