### PR TITLE
Loader: streamline isComment()

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -147,7 +147,8 @@ class Loader
      */
     protected function isComment($line)
     {
-        return strpos(ltrim($line), '#') === 0;
+        $line = ltrim($line);
+        return $line[0] === '#';
     }
 
     /**


### PR DESCRIPTION
Skip using strpos() because we already know the string position that needs to be checked.