### PR TITLE
Dotenv: Unused Loader instance in __construct

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -35,7 +35,9 @@ class Dotenv
     public function __construct($path, $file = '.env')
     {
         $this->filePath = $this->getFilePath($path, $file);
-        $this->loader = new Loader($this->filePath, true);
+
+        // This loader is only a placeholder so that Validate can work.
+        $this->loader = new Loader('');
     }
 
     /**


### PR DESCRIPTION
loadData() will always create a Loader instance, so creating one in Dotenv::__construct() is only useful for Validate.

Hopefully travis agrees.