### PR TITLE
Loader: streamline isComment() with whitespace test

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -147,7 +147,9 @@ class Loader
      */
     protected function isComment($line)
     {
-        return strpos(ltrim($line), '#') === 0;
+        $line = ltrim($line);
+
+        return isset($line[0]) && $line[0] === '#';
     }
 
     /**

--- a/tests/fixtures/.env
+++ b/tests/fixtures/.env
@@ -3,3 +3,4 @@ BAR=baz
 SPACED=with spaces
 
 NULL=
+  


### PR DESCRIPTION
Note: `isset()` is a language construct and therefore does not incur the overhead of a true function call.

Supersedes #209.