### PR TITLE
Loader: avoid wasteful strpbrk, array_key_exists

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -312,7 +312,7 @@ class Loader
      */
     protected function beginsWithAQuote($value)
     {
-        return strpbrk($value[0], '"\'') !== false;
+        return isset($value[0]) && ($value[0] === '"' || $value[0] === '\'');
     }
 
     /**
@@ -325,9 +325,9 @@ class Loader
     public function getEnvironmentVariable($name)
     {
         switch (true) {
-            case array_key_exists($name, $_ENV):
+            case isset($_ENV[$name]):
                 return $_ENV[$name];
-            case array_key_exists($name, $_SERVER):
+            case isset($_SERVER[$name]):
                 return $_SERVER[$name];
             default:
                 $value = getenv($name);


### PR DESCRIPTION
`array_key_exists()` could return `true` when the value is set to `null`, the same result is considered to be a failure in the `default:` case. This may prevent a value in `$_SERVER` from being used.

`strpbrk()` is a rarely used function that behaves like `strstr()` and returns a substring on success. Given that we are only checking a single character for specific values, `isset()` (a language construct that does not incur standard function overhead) is more suitable for performance and legibility.