### PR TITLE
Loader: use isset instead of strpbrk

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -312,7 +312,7 @@ class Loader
      */
     protected function beginsWithAQuote($value)
     {
-        return strpbrk($value[0], '"\'') !== false;
+        return isset($value[0]) && ($value[0] === '"' || $value[0] === '\'');
     }
 
     /**


### PR DESCRIPTION
Supercedes #220:

`strpbrk()` is a rarely used function that behaves like `strstr()` and returns a substring on success. Given that we are only checking a single character for specific values, `isset()` (a language construct that does not incur standard function overhead) is more suitable for performance and legibility.