### PR TITLE
Adding option to ignore .env file requirement

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -41,11 +41,17 @@ class Dotenv
     /**
      * Load environment file in given directory.
      *
+     * @param bool $requireDotEnv
+     *
      * @return array
      */
-    public function load()
+    public function load($requireDotenv = true)
     {
-        return $this->loadData();
+        if ($requireDotenv) {
+            return $this->loadData();
+        }
+
+        return array();
     }
 
     /**

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -24,6 +24,13 @@ class DotenvTest extends PHPUnit_Framework_TestCase
         $dotenv->load();
     }
 
+    public function testDotenvDoesNotThrowExceptionWhenLoadRequirementIsFalse()
+    {
+        $dotenv = new Dotenv(__DIR__);
+        $lines = array();
+        $this->assertSame($lines, $dotenv->load(false));
+    }
+
     public function testDotenvLoadsEnvironmentVars()
     {
         $dotenv = new Dotenv($this->fixturesFolder);


### PR DESCRIPTION
The Ruby dotenv implementation has 2 load methods (load, load!). The load method ignores a missing .env file for the case where you are in a non-development environment and have your environment variables set by some other method.

I would like the same options for phpdotenv.

For backwards compatibility I have added an optional flag to load() to ignore the requirement of having a .env file. By default it is true.