### PR TITLE
Fix incorrect nesting documentation

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -260,7 +260,7 @@ class Loader
     /**
      * Resolve the nested variables.
      *
-     * Look for {$varname} patterns in the variable value and replace with an
+     * Look for ${varname} patterns in the variable value and replace with an
      * existing environment variable.
      *
      * @param string $value


### PR DESCRIPTION
`{$variable}` does not work, but `${variable}` does. The docblock for the respolveNestedVariables method is incorrect.