### PR TITLE
[PROPOSAL] Added getter for the loader.

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -59,6 +59,16 @@ class Dotenv
     }
 
     /**
+     * Loader getter 
+     * 
+     * @return Loader
+     */
+    public function getLoader()
+    {
+        return $this->loader;
+    }
+
+    /**
      * Returns the full path to the file.
      *
      * @param string $path


### PR DESCRIPTION
This is a proposal to make the loader public. The reason for this is that, while the `Loader`'s  `setEnvironmentVariable` method is marked as public, there is no way to access it from a `DotEnv` instance. This leaves you with two options, either extend the class to expose it, or initiating a new `Loader` just to give access to the method. This solves that problem. 

Use case for this would be needing to add an environment variable programmatically like a define, but still be able to retain in the rest of the code the use of `getenv`. An example of where I could of used this is at https://github.com/QuintanaTech/site/blob/master/web/env.php. 