### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.0"
+        "phpunit/phpunit": "^4.8.35 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Dotenv\Dotenv;
+use PHPUnit\Framework\TestCase;
 
-class DotenvTest extends PHPUnit_Framework_TestCase
+class DotenvTest extends TestCase
 {
     /**
      * @var string

--- a/tests/Dotenv/LoaderTest.php
+++ b/tests/Dotenv/LoaderTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Dotenv\Loader;
+use PHPUnit\Framework\TestCase;
 
-class LoaderTest extends PHPUnit_Framework_TestCase
+class LoaderTest extends TestCase
 {
     /**
      * @var \Dotenv\Loader
@@ -13,7 +14,7 @@ class LoaderTest extends PHPUnit_Framework_TestCase
      * @var \Dotenv\Loader
      */
     private $mutableLoader;
-    
+
     public function setUp()
     {
         $folder = dirname(__DIR__) . '/fixtures/env';


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.