### PR TITLE
Fix typo in `Loader::getImmutable` description

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -56,7 +56,7 @@ class Loader
     }
 
     /**
-     * Set immutable value.
+     * Get immutable value.
      *
      * @return bool
      */


### PR DESCRIPTION
Fixing a little typo in comment for `Loader::getImmutable` method.