### PR TITLE
Make license field to match actual LICENSE.md

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "vlucas/phpdotenv",
     "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
     "keywords": ["env", "dotenv", "environment"],
-    "license" : "BSD-3-Clause-Attribution",
+    "license" : "BSD-3-Clause",
     "authors" : [
         {
             "name": "Vance Lucas",


### PR DESCRIPTION
Hello! 

Firstly I want to thank you for this package. I'm using it in almost all my PHP projects ant it is very helpful.

In `composer.json` you are using `"BSD-3-Clause-Attribution"` license type, which is actually 4-clause. The 4th clause should be like this:

> Redistributions of any form whatsoever must retain the following acknowledgment:
> 'This product includes software developed by Vance Lucas (http://www.vancelucas.com).'

But your `LICENSE.md` is original BSD-3-Clause. Seeing that `composer.json` license field was not commited by you, I am making this PR with `LICENSE.md` priority. If you want to use BSD-3-Clause-Attribution, you shoul add 4th clause to your `LICENSE.md`