### PR TITLE
Multiline support

### DIFF
--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -261,17 +261,20 @@ class DotenvTest extends TestCase
         $this->assertEmpty(getenv('ASSERTVAR2'));
         $this->assertEmpty(getenv('ASSERTVAR3'));
         $this->assertSame('0', getenv('ASSERTVAR4'));
+        $this->assertSame("val1\nval2", getenv('ASSERTVAR5'));
 
         $dotenv->required(array(
             'ASSERTVAR1',
             'ASSERTVAR2',
             'ASSERTVAR3',
             'ASSERTVAR4',
+            'ASSERTVAR5',
         ));
 
         $dotenv->required(array(
             'ASSERTVAR1',
             'ASSERTVAR4',
+            'ASSERTVAR5'
         ))->notEmpty();
 
         $dotenv->required(array(

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -262,6 +262,8 @@ class DotenvTest extends TestCase
         $this->assertEmpty(getenv('ASSERTVAR3'));
         $this->assertSame('0', getenv('ASSERTVAR4'));
         $this->assertSame("val1\nval2", getenv('ASSERTVAR5'));
+        $this->assertSame("val3", getenv('ASSERTVAR6'));
+        $this->assertSame("val3", getenv('ASSERTVAR7'));
 
         $dotenv->required(array(
             'ASSERTVAR1',
@@ -269,18 +271,23 @@ class DotenvTest extends TestCase
             'ASSERTVAR3',
             'ASSERTVAR4',
             'ASSERTVAR5',
+            'ASSERTVAR6',
         ));
 
         $dotenv->required(array(
             'ASSERTVAR1',
             'ASSERTVAR4',
-            'ASSERTVAR5'
+            'ASSERTVAR5',
+            'ASSERTVAR6',
+            'ASSERTVAR7'
         ))->notEmpty();
 
         $dotenv->required(array(
             'ASSERTVAR1',
             'ASSERTVAR4',
-        ))->notEmpty()->allowedValues(array('0', 'val1'));
+            'ASSERTVAR6',
+            'ASSERTVAR7',
+        ))->notEmpty()->allowedValues(array('0', 'val1', 'val3'));
 
         $this->assertTrue(true); // anything wrong an an exception will be thrown
     }

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -264,6 +264,7 @@ class DotenvTest extends TestCase
         $this->assertSame("val1\nval2", getenv('ASSERTVAR5'));
         $this->assertSame("val3", getenv('ASSERTVAR6'));
         $this->assertSame("val3", getenv('ASSERTVAR7'));
+        $this->assertEmpty(getenv('ASSERTVAR8'));
 
         $dotenv->required(array(
             'ASSERTVAR1',
@@ -272,6 +273,8 @@ class DotenvTest extends TestCase
             'ASSERTVAR4',
             'ASSERTVAR5',
             'ASSERTVAR6',
+            'ASSERTVAR7',
+            'ASSERTVAR8',
         ));
 
         $dotenv->required(array(

--- a/tests/fixtures/env/assertions.env
+++ b/tests/fixtures/env/assertions.env
@@ -2,3 +2,5 @@ ASSERTVAR1="val1"
 ASSERTVAR2=""
 ASSERTVAR3="   "
 ASSERTVAR4="0" # empty looking value
+ASSERTVAR5="val1
+val2"

--- a/tests/fixtures/env/assertions.env
+++ b/tests/fixtures/env/assertions.env
@@ -4,3 +4,7 @@ ASSERTVAR3="   "
 ASSERTVAR4="0" # empty looking value
 ASSERTVAR5="val1
 val2"
+ASSERTVAR6="
+val3"
+ASSERTVAR7="val3
+"

--- a/tests/fixtures/env/assertions.env
+++ b/tests/fixtures/env/assertions.env
@@ -5,6 +5,8 @@ ASSERTVAR4="0" # empty looking value
 ASSERTVAR5="val1
 val2"
 ASSERTVAR6="
-val3"
+val3" #
 ASSERTVAR7="val3
+"
+ASSERTVAR8="
 "


### PR DESCRIPTION
This pull request add multiline support for `.env` files.

It's the behavior I choosed. If you have a better way or comments, please tell me.
Same for tests, I tried to cover most cases but I can have forget some.

# Related issues
- #261 

# How it works
It follows bash behavior:
```
MY_VARIABLE="value1
value2"
```