### PR TITLE
Robust comments

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -246,6 +246,11 @@ class Loader
             $parts = explode(' #', $value, 2);
             $value = trim($parts[0]);
 
+            // Check if value is a comment (usually triggered when empty value with comment)
+            if (preg_match('/^#/', $value) > 0) {
+                $value = '';
+            }
+
             // Unquoted values cannot contain whitespace
             if (preg_match('/\s+/', $value) > 0) {
                 throw new InvalidFileException('Dotenv values containing spaces must be surrounded by quotes.');

--- a/tests/fixtures/env/commented.env
+++ b/tests/fixtures/env/commented.env
@@ -5,8 +5,8 @@ CFOO=bar
 CSPACED="with spaces" # this is a comment
 CQUOTES="a value with a # character" # this is a comment
 CQUOTESWITHQUOTE="a value with a # character & a quote \" character inside quotes" # " this is a comment
-EMPTY=  # comment with empty variable
-BOOLEAN=yes  # (yes, no)
+EMPTY= # comment with empty variable
+BOOLEAN=yes # (yes, no)
 
 CNULL=
 

--- a/tests/fixtures/env/commented.env
+++ b/tests/fixtures/env/commented.env
@@ -5,6 +5,8 @@ CFOO=bar
 CSPACED="with spaces" # this is a comment
 CQUOTES="a value with a # character" # this is a comment
 CQUOTESWITHQUOTE="a value with a # character & a quote \" character inside quotes" # " this is a comment
+EMPTY=  # comment with empty variable
+BOOLEAN=yes  # (yes, no)
 
 CNULL=
 


### PR DESCRIPTION
Following linked issue, making loading more robust by handling comments on empty variable.

# Related issues
- #236 

# How to reproduce
```
EMPTY= # comment with empty variable
```