### PR TITLE
Trimed values

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -252,7 +252,7 @@ class Loader
             }
         }
 
-        return array($name, trim($value));
+        return array($name, $value);
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -56,7 +56,7 @@ class Validator
     {
         return $this->assertCallback(
             function ($value) {
-                return strlen(trim($value)) > 0;
+                return strlen($value) > 0;
             },
             'is empty'
         );

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -259,7 +259,7 @@ class DotenvTest extends TestCase
         $dotenv->load();
         $this->assertSame('val1', getenv('ASSERTVAR1'));
         $this->assertEmpty(getenv('ASSERTVAR2'));
-        $this->assertSame('   ', getenv('ASSERTVAR3'));
+        $this->assertSame('val3   ', getenv('ASSERTVAR3'));
         $this->assertSame('0', getenv('ASSERTVAR4'));
 
         $dotenv->required(array(

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -259,7 +259,7 @@ class DotenvTest extends TestCase
         $dotenv->load();
         $this->assertSame('val1', getenv('ASSERTVAR1'));
         $this->assertEmpty(getenv('ASSERTVAR2'));
-        $this->assertEmpty(getenv('ASSERTVAR3'));
+        $this->assertSame('   ', getenv('ASSERTVAR3'));
         $this->assertSame('0', getenv('ASSERTVAR4'));
 
         $dotenv->required(array(
@@ -271,6 +271,7 @@ class DotenvTest extends TestCase
 
         $dotenv->required(array(
             'ASSERTVAR1',
+            'ASSERTVAR3',
             'ASSERTVAR4',
         ))->notEmpty();
 
@@ -293,30 +294,6 @@ class DotenvTest extends TestCase
         $this->assertEmpty(getenv('ASSERTVAR2'));
 
         $dotenv->required('ASSERTVAR2')->notEmpty();
-    }
-
-    /**
-     * @expectedException \Dotenv\Exception\ValidationException
-     * @expectedExceptionMessage One or more environment variables failed assertions: ASSERTVAR3 is empty.
-     */
-    public function testDotenvStringOfSpacesConsideredEmpty()
-    {
-        $dotenv = new Dotenv($this->fixturesFolder, 'assertions.env');
-        $dotenv->load();
-        $this->assertEmpty(getenv('ASSERTVAR3'));
-
-        $dotenv->required('ASSERTVAR3')->notEmpty();
-    }
-
-    /**
-     * @expectedException \Dotenv\Exception\ValidationException
-     * @expectedExceptionMessage One or more environment variables failed assertions: ASSERTVAR3 is empty.
-     */
-    public function testDotenvHitsLastChain()
-    {
-        $dotenv = new Dotenv($this->fixturesFolder, 'assertions.env');
-        $dotenv->load();
-        $dotenv->required('ASSERTVAR3')->notEmpty();
     }
 
     /**

--- a/tests/fixtures/env/assertions.env
+++ b/tests/fixtures/env/assertions.env
@@ -1,4 +1,4 @@
 ASSERTVAR1="val1"
 ASSERTVAR2=""
-ASSERTVAR3="   "
+ASSERTVAR3="val3   "
 ASSERTVAR4="0" # empty looking value


### PR DESCRIPTION
Changing value behavior by not trimming explicit values.

⚠️ Since it's changing behavior for spaces in variables, it should be added only in major version to avoid having unexpected issues.

# Related issue
- #234