### PR TITLE
Fix PREG_JIT_STACKLIMIT_ERROR

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -226,16 +226,16 @@ class Loader
             $quote = $value[0];
             $regexPattern = sprintf(
                 '/^
-                %1$s          # match a quote at the start of the value
-                (             # capturing sub-pattern used
-                 (?:          # we do not need to capture this
-                  [^%1$s\\\\] # any character other than a quote or backslash
-                  |\\\\\\\\   # or two backslashes together
-                  |\\\\%1$s   # or an escaped quote e.g \"
-                 )*           # as many characters that match the previous rules
-                )             # end of the capturing sub-pattern
-                %1$s          # and the closing quote
-                .*$           # and discard any string after the closing quote
+                %1$s           # match a quote at the start of the value
+                (              # capturing sub-pattern used
+                 (?:           # we do not need to capture this
+                  [^%1$s\\\\]* # any character other than a quote or backslash
+                  |\\\\\\\\    # or two backslashes together
+                  |\\\\%1$s    # or an escaped quote e.g \"
+                 )*            # as many characters that match the previous rules
+                )              # end of the capturing sub-pattern
+                %1$s           # and the closing quote
+                .*$            # and discard any string after the closing quote
                 /mx',
                 $quote
             );


### PR DESCRIPTION
without the asterisk it uses too much memory, silently ignoring anything that exceeds the limits.