### PR TITLE
Added some additional exceptions

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -252,12 +252,12 @@ class Loader
                 $l = get_defined_constants(true);
                 $l = $l['pcre'];
                 $l = array_flip($l);
-                throw new \RuntimeException($l[$e]);
+                throw new InvalidFileException($l[$e]);
             }
 
-            //if they are identical, it failed to replace/match
+            // if they are identical, it failed to replace/match
             if($originalValue === $value) {
-                throw new \RuntimeException("Invalid value");
+                throw new InvalidFileException("Invalid value");
             }
             $value = str_replace("\\$quote", $quote, $value);
             $value = str_replace('\\\\', '\\', $value);

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -236,7 +236,7 @@ class Loader
                 %1$s           # match a quote at the start of the value
                 (              # capturing sub-pattern used
                  (?:           # we do not need to capture this
-                  [^%1$s\\\\]* # any character other than a quote or backslash
+                  [^%1$s\\\\]+ # any character other than a quote or backslash
                   |\\\\\\\\    # or two backslashes together
                   |\\\\%1$s    # or an escaped quote e.g \"
                  )*            # as many characters that match the previous rules
@@ -246,7 +246,19 @@ class Loader
                 /mx',
                 $quote
             );
+            $originalValue = $value;
             $value = preg_replace($regexPattern, '$1', $value);
+            if(($e = preg_last_error()) !== PREG_NO_ERROR) {
+                $l = get_defined_constants(true);
+                $l = $l['pcre'];
+                $l = array_flip($l);
+                throw new \RuntimeException($l[$e]);
+            }
+
+            //if they are identical, it failed to replace/match
+            if($originalValue === $value) {
+                throw new \RuntimeException("Invalid value");
+            }
             $value = str_replace("\\$quote", $quote, $value);
             $value = str_replace('\\\\', '\\', $value);
         } else {


### PR DESCRIPTION
This doesn't fix "\n" being parsed or even empty values.  It throws exceptions when preg_replace fails or does nothing.  I'm not sure if you'd like additional exception types added.  Just provide some feedback if you'd like some changes.