### PR TITLE
Broken up the loader, and made load() return the actual environment variables

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -10,7 +10,7 @@ use Dotenv\Exception\InvalidPathException;
  * This is the dotenv class.
  *
  * It's responsible for loading a `.env` file in the given directory and
- * setting the environment vars.
+ * setting the environment variables.
  */
 class Dotenv
 {
@@ -53,7 +53,6 @@ class Dotenv
         return new self($loader);
     }
 
-
     /**
      * Returns the full path to the file.
      *
@@ -76,7 +75,7 @@ class Dotenv
      *
      * @throws \Dotenv\Exception\InvalidPathException|\Dotenv\Exception\InvalidFileException
      *
-     * @return array
+     * @return string[]
      */
     public function load()
     {
@@ -84,9 +83,11 @@ class Dotenv
     }
 
     /**
-     * Load environment file in given directory, suppress InvalidPathException.
+     * Load environment file in given directory, silently failing if it doesn't exist.
      *
-     * @return array
+     * @throws \Dotenv\Exception\InvalidFileException
+     *
+     * @return string[]
      */
     public function safeLoad()
     {
@@ -103,7 +104,7 @@ class Dotenv
      *
      * @throws \Dotenv\Exception\InvalidPathException|\Dotenv\Exception\InvalidFileException
      *
-     * @return array
+     * @return string[]
      */
     public function overload()
     {
@@ -117,7 +118,7 @@ class Dotenv
      *
      * @throws \Dotenv\Exception\InvalidPathException|\Dotenv\Exception\InvalidFileException
      *
-     * @return array
+     * @return string[]
      */
     protected function loadData($overload = false)
     {

--- a/src/Lines.php
+++ b/src/Lines.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Dotenv;
+
+class Lines
+{
+    /**
+     * Process the array of lines of environment variables.
+     *
+     * This will produce an array of entries, one per variable.
+     *
+     * @param string[] $lines
+     *
+     * @return string[]
+     */
+    public static function process(array $lines)
+    {
+        $output = [];
+        $multiline = false;
+        $multilineBuffer = [];
+
+        foreach ($lines as $line) {
+            list($multiline, $line, $multilineBuffer) = self::multilineProcess($multiline, $line, $multilineBuffer);
+
+            if (!$multiline && !self::isComment($line) && self::looksLikeSetter($line)) {
+                $output[] = $line;
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Used to make all multiline variable process.
+     *
+     * @param bool     $multiline
+     * @param string   $line
+     * @param string[] $buffer
+     *
+     * @return string[]
+     */
+    private static function multilineProcess($multiline, $line, array $buffer)
+    {
+        // check if $line can be multiline variable
+        if (self::looksLikeMultilineStart($line)) {
+            $multiline = true;
+        }
+
+        if ($multiline) {
+            array_push($buffer, $line);
+
+            if (self::looksLikeMultilineStop($line)) {
+                $multiline = false;
+                $line = implode("\n", $buffer);
+                $buffer = [];
+            }
+        }
+
+        return [$multiline, $line, $buffer];
+    }
+
+    /**
+     * Determine if the given line can be the start of a multiline variable.
+     *
+     * @param string $line
+     *
+     * @return bool
+     */
+    private static function looksLikeMultilineStart($line)
+    {
+        return strpos($line, '="') !== false && substr_count($line, '"') === 1;
+    }
+
+    /**
+     * Determine if the given line can be the start of a multiline variable.
+     *
+     * @param string $line
+     *
+     * @return bool
+     */
+    private static function looksLikeMultilineStop($line)
+    {
+        return strpos($line, '"') !== false && substr_count($line, '="') === 0;
+    }
+
+    /**
+     * Determine if the line in the file is a comment, e.g. begins with a #.
+     *
+     * @param string $line
+     *
+     * @return bool
+     */
+    private static function isComment($line)
+    {
+        $line = ltrim($line);
+
+        return isset($line[0]) && $line[0] === '#';
+    }
+
+    /**
+     * Determine if the given line looks like it's setting a variable.
+     *
+     * @param string $line
+     *
+     * @return bool
+     */
+    private static function looksLikeSetter($line)
+    {
+        return strpos($line, '=') !== false;
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -3,7 +3,6 @@
 namespace Dotenv;
 
 use Dotenv\Environment\FactoryInterface;
-use Dotenv\Exception\InvalidFileException;
 use Dotenv\Exception\InvalidPathException;
 
 /**
@@ -82,88 +81,13 @@ class Loader
      *
      * @throws \Dotenv\Exception\InvalidPathException|\Dotenv\Exception\InvalidFileException
      *
-     * @return array
+     * @return string[]
      */
     public function load()
     {
-        $this->ensureFileIsReadable();
-
-        $filePath = $this->filePath;
-        $lines = $this->readLinesFromFile($filePath);
-
-        // multiline
-        $multiline = false;
-        $multilineBuffer = [];
-
-        foreach ($lines as $line) {
-            list($multiline, $line, $multilineBuffer) = $this->multilineProcess($multiline, $line, $multilineBuffer);
-
-            if (!$multiline && !$this->isComment($line) && $this->looksLikeSetter($line)) {
-                $this->setEnvironmentVariable($line);
-            }
-        }
-
-        return $lines;
-    }
-
-    /**
-     * Ensures the given filePath is readable.
-     *
-     * @throws \Dotenv\Exception\InvalidPathException
-     *
-     * @return void
-     */
-    protected function ensureFileIsReadable()
-    {
-        if (!is_readable($this->filePath) || !is_file($this->filePath)) {
-            throw new InvalidPathException(sprintf('Unable to read the environment file at %s.', $this->filePath));
-        }
-    }
-
-    /**
-     * Normalise the given environment variable.
-     *
-     * Takes value as passed in by developer and:
-     * - ensures we're dealing with a separate name and value, breaking apart the name string if needed,
-     * - cleaning the value of quotes,
-     * - cleaning the name of quotes,
-     * - resolving nested variables.
-     *
-     * @param string      $name
-     * @param string|null $value
-     *
-     * @throws \Dotenv\Exception\InvalidFileException
-     *
-     * @return array
-     */
-    protected function normaliseEnvironmentVariable($name, $value)
-    {
-        list($name, $value) = $this->processFilters($name, $value);
-
-        $value = $this->resolveNestedVariables($value);
-
-        return [$name, $value];
-    }
-
-    /**
-     * Process the runtime filters.
-     *
-     * Called from `normaliseEnvironmentVariable` and the `VariableFactory`, passed as a callback in `$this->loadFromFile()`.
-     *
-     * @param string      $name
-     * @param string|null $value
-     *
-     * @throws \Dotenv\Exception\InvalidFileException
-     *
-     * @return array
-     */
-    public function processFilters($name, $value)
-    {
-        list($name, $value) = $this->splitCompoundStringIntoParts($name, $value);
-        list($name, $value) = $this->sanitiseVariableName($name, $value);
-        list($name, $value) = $this->sanitiseVariableValue($name, $value);
-
-        return [$name, $value];
+        return $this->processEntries(
+            Lines::process(self::readLinesFromFile($this->filePath))
+        );
     }
 
     /**
@@ -171,169 +95,47 @@ class Loader
      *
      * @param string $filePath
      *
-     * @return array
+     * @throws \Dotenv\Exception\InvalidPathException
+     *
+     * @return string[]
      */
-    protected function readLinesFromFile($filePath)
+    private static function readLinesFromFile($filePath)
     {
-        // Read file into an array of lines with auto-detected line endings
         $autodetect = ini_get('auto_detect_line_endings');
         ini_set('auto_detect_line_endings', '1');
-        $lines = file($filePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $lines = @file($filePath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         ini_set('auto_detect_line_endings', $autodetect);
+
+        if ($lines === false) {
+            throw new InvalidPathException(
+                sprintf('Unable to read the environment file at %s.', $filePath)
+            );
+        }
 
         return $lines;
     }
 
     /**
-     * Used to make all multiline variable process.
+     * Process the environment variable entries.
      *
-     * @param bool   $multiline
-     * @param string $line
-     * @param array  $buffer
+     * We'll fill out any nested variables, and acually set the variable using
+     * the underlying environment variables instance.
      *
-     * @return array
+     * @param string[] $entries
+     *
+     * @return string[]
      */
-    protected function multilineProcess($multiline, $line, $buffer)
+    private function processEntries(array $entries)
     {
-        // check if $line can be multiline variable
-        if ($this->looksLikeMultilineStart($line)) {
-            $multiline = true;
-        }
-        if ($multiline) {
-            array_push($buffer, $line);
+        $vars = [];
 
-            if ($this->looksLikeMultilineStop($line)) {
-                $multiline = false;
-                $line = implode("\n", $buffer);
-                $buffer = [];
-            }
+        foreach ($entries as $entry) {
+            list($name, $value) = Parser::parse($entry);
+            $vars[$name] = $this->resolveNestedVariables($value);
+            $this->setEnvironmentVariable($name, $vars[$name]);
         }
 
-        return [$multiline, $line, $buffer];
-    }
-
-    /**
-     * Determine if the line in the file is a comment, e.g. begins with a #.
-     *
-     * @param string $line
-     *
-     * @return bool
-     */
-    protected function isComment($line)
-    {
-        $line = ltrim($line);
-
-        return isset($line[0]) && $line[0] === '#';
-    }
-
-    /**
-     * Determine if the given line looks like it's setting a variable.
-     *
-     * @param string $line
-     *
-     * @return bool
-     */
-    protected function looksLikeSetter($line)
-    {
-        return strpos($line, '=') !== false;
-    }
-
-    /**
-     * Determine if the given line can be the start of a multiline variable.
-     *
-     * @param string $line
-     *
-     * @return bool
-     */
-    protected function looksLikeMultilineStart($line)
-    {
-        return strpos($line, '="') !== false && substr_count($line, '"') === 1;
-    }
-
-    /**
-     * Determine if the given line can be the start of a multiline variable.
-     *
-     * @param string $line
-     *
-     * @return bool
-     */
-    protected function looksLikeMultilineStop($line)
-    {
-        return strpos($line, '"') !== false && substr_count($line, '="') === 0;
-    }
-
-    /**
-     * Split the compound string into parts.
-     *
-     * If the `$name` contains an `=` sign, then we split it into 2 parts, a `name` & `value`
-     * disregarding the `$value` passed in.
-     *
-     * @param string      $name
-     * @param string|null $value
-     *
-     * @return array
-     */
-    protected function splitCompoundStringIntoParts($name, $value)
-    {
-        if (strpos($name, '=') !== false) {
-            list($name, $value) = array_map('trim', explode('=', $name, 2));
-        }
-
-        return [$name, $value];
-    }
-
-    /**
-     * Strips quotes from the environment variable value.
-     *
-     * @param string      $name
-     * @param string|null $value
-     *
-     * @throws \Dotenv\Exception\InvalidFileException
-     *
-     * @return array
-     */
-    protected function sanitiseVariableValue($name, $value)
-    {
-        if ($value === null || trim($value) === '') {
-            return [$name, $value];
-        }
-
-        if ($this->beginsWithAQuote($value)) { // value starts with a quote
-            $quote = $value[0];
-            $regexPattern = sprintf(
-                '/^
-                %1$s           # match a quote at the start of the value
-                (              # capturing sub-pattern used
-                 (?:           # we do not need to capture this
-                  [^%1$s\\\\]+ # any character other than a quote or backslash
-                  |\\\\\\\\    # or two backslashes together
-                  |\\\\%1$s    # or an escaped quote e.g \"
-                 )*            # as many characters that match the previous rules
-                )              # end of the capturing sub-pattern
-                %1$s           # and the closing quote
-                .*$            # and discard any string after the closing quote
-                /mx',
-                $quote
-            );
-            $value = preg_replace($regexPattern, '$1', $value);
-            $value = str_replace("\\$quote", $quote, $value);
-            $value = str_replace('\\\\', '\\', $value);
-        } else {
-            $parts = explode(' #', $value, 2);
-            $value = $parts[0];
-
-            // Unquoted values cannot contain whitespace
-            if (preg_match('/\s+/', $value) > 0) {
-                // Check if value is a comment (usually triggered when empty value with comment)
-                if (preg_match('/^#/', $value) > 0) {
-                    $value = '';
-                } else {
-                    throw new InvalidFileException('Dotenv values containing spaces must be surrounded by quotes.');
-                }
-            }
-        }
-
-        return [$name, $value];
+        return $vars;
     }
 
     /**
@@ -342,56 +144,28 @@ class Loader
      * Look for ${varname} patterns in the variable value and replace with an
      * existing environment variable.
      *
-     * @param string $value
+     * @param string|null $value
      *
-     * @return mixed
+     * @return string|null
      */
-    protected function resolveNestedVariables($value)
+    private function resolveNestedVariables($value = null)
     {
-        if (strpos($value, '$') !== false) {
-            $loader = $this;
-            $value = preg_replace_callback(
-                '/\${([a-zA-Z0-9_.]+)}/',
-                function ($matchedPatterns) use ($loader) {
-                    $nestedVariable = $loader->getEnvironmentVariable($matchedPatterns[1]);
-                    if ($nestedVariable === null) {
-                        return $matchedPatterns[0];
-                    } else {
-                        return $nestedVariable;
-                    }
-                },
-                $value
-            );
+        if ($value === null || strpos($value, '$') === false) {
+            return $value;
         }
 
-        return $value;
+        return preg_replace_callback(
+            '/\${([a-zA-Z0-9_.]+)}/',
+            [$this, 'nestedVariableResolver'],
+            $value
+        );
     }
 
-    /**
-     * Strips quotes and the optional leading "export " from the environment variable name.
-     *
-     * @param string $name
-     * @param string $value
-     *
-     * @return array
-     */
-    protected function sanitiseVariableName($name, $value)
+    private function nestedVariableResolver(array $matches)
     {
-        $name = trim(str_replace(['export ', '\'', '"'], '', $name));
+        $nested = $this->getEnvironmentVariable($matches[1]);
 
-        return [$name, $value];
-    }
-
-    /**
-     * Determine if the given string begins with a quote.
-     *
-     * @param string $value
-     *
-     * @return bool
-     */
-    protected function beginsWithAQuote($value)
-    {
-        return isset($value[0]) && ($value[0] === '"' || $value[0] === '\'');
+        return $nested === null ? $matches[0] : $nested;
     }
 
     /**
@@ -409,21 +183,14 @@ class Loader
     /**
      * Set an environment variable.
      *
-     * The environment variable value is stripped of single and double quotes.
-     *
      * @param string      $name
      * @param string|null $value
-     *
-     * @throws \Dotenv\Exception\InvalidFileException
      *
      * @return void
      */
     public function setEnvironmentVariable($name, $value = null)
     {
-        list($name, $value) = $this->normaliseEnvironmentVariable($name, $value);
-
         $this->variableNames[] = $name;
-
         $this->envVariables->set($name, $value);
     }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Dotenv;
+
+use Dotenv\Exception\InvalidFileException;
+
+class Parser
+{
+    /**
+     * Parse the given environment variable entry into a name and value.
+     *
+     * Takes value as passed in by developer and:
+     * - breaks up the line into a name and value,
+     * - cleaning the value of quotes,
+     * - cleaning the name of quotes.
+     *
+     * @param string $entry
+     *
+     * @throws \Dotenv\Exception\InvalidFileException
+     *
+     * @return array
+     */
+    public static function parse($entry)
+    {
+        list($name, $value) = self::splitStringIntoParts($entry);
+
+        return [self::sanitiseName($name), self::sanitiseValue($value)];
+    }
+
+    /**
+     * Split the compound string into parts.
+     *
+     * If the `$line` contains an `=` sign, then we split it into 2 parts.
+     *
+     * @param string $line
+     *
+     * @return array
+     */
+    private static function splitStringIntoParts($line)
+    {
+        $name = $line;
+        $value = null;
+
+        if (strpos($line, '=') !== false) {
+            list($name, $value) = array_map('trim', explode('=', $line, 2));
+        }
+
+        return [$name, $value];
+    }
+
+    /**
+     * Strips quotes and the optional leading "export " from the variable name.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    private static function sanitiseName($name)
+    {
+        return trim(str_replace(['export ', '\'', '"'], '', $name));
+    }
+
+    /**
+     * Strips quotes from the environment variable value.
+     *
+     * @param string|null $value
+     *
+     * @throws \Dotenv\Exception\InvalidFileException
+     *
+     * @return string|null
+     */
+    private static function sanitiseValue($value)
+    {
+        if ($value === null || trim($value) === '') {
+            return $value;
+        }
+
+        if (self::beginsWithAQuote($value)) { // value starts with a quote
+            $quote = $value[0];
+            $regexPattern = sprintf(
+                '/^
+                %1$s           # match a quote at the start of the value
+                (              # capturing sub-pattern used
+                 (?:           # we do not need to capture this
+                  [^%1$s\\\\]+ # any character other than a quote or backslash
+                  |\\\\\\\\    # or two backslashes together
+                  |\\\\%1$s    # or an escaped quote e.g \"
+                 )*            # as many characters that match the previous rules
+                )              # end of the capturing sub-pattern
+                %1$s           # and the closing quote
+                .*$            # and discard any string after the closing quote
+                /mx',
+                $quote
+            );
+            $value = preg_replace($regexPattern, '$1', $value);
+            $value = str_replace("\\$quote", $quote, $value);
+            $value = str_replace('\\\\', '\\', $value);
+        } else {
+            $parts = explode(' #', $value, 2);
+            $value = $parts[0];
+
+            // Unquoted values cannot contain whitespace
+            if (preg_match('/\s+/', $value) > 0) {
+                // Check if value is a comment (usually triggered when empty value with comment)
+                if (preg_match('/^#/', $value) > 0) {
+                    $value = '';
+                } else {
+                    throw new InvalidFileException(
+                        'Dotenv values containing spaces must be surrounded by quotes.'
+                    );
+                }
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Determine if the given string begins with a quote.
+     *
+     * @param string $value
+     *
+     * @return bool
+     */
+    private static function beginsWithAQuote($value)
+    {
+        return isset($value[0]) && ($value[0] === '"' || $value[0] === '\'');
+    }
+}

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -34,7 +34,10 @@ class DotenvTest extends TestCase
     public function testDotenvLoadsEnvironmentVars()
     {
         $dotenv = Dotenv::create($this->fixturesFolder);
-        $dotenv->load();
+        $this->assertSame(
+            ['FOO' => 'bar', 'BAR' => 'baz', 'SPACED' => 'with spaces', 'NULL' => ''],
+            $dotenv->load()
+        );
         $this->assertSame('bar', getenv('FOO'));
         $this->assertSame('baz', getenv('BAR'));
         $this->assertSame('with spaces', getenv('SPACED'));

--- a/tests/Dotenv/LinesTest.php
+++ b/tests/Dotenv/LinesTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Dotenv\Lines;
+use PHPUnit\Framework\TestCase;
+
+class LinesTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected $autodetect;
+
+    public function setUp()
+    {
+        $this->autodetect = ini_get('auto_detect_line_endings');
+        ini_set('auto_detect_line_endings', '1');
+    }
+
+    public function tearDown()
+    {
+        ini_set('auto_detect_line_endings', $this->autodetect);
+    }
+
+    public function testProcess()
+    {
+        $content = file(
+            dirname(__DIR__).'/fixtures/env/assertions.env',
+            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
+        );
+
+        $expected = [
+            'ASSERTVAR1=val1',
+            'ASSERTVAR2=""',
+            'ASSERTVAR3="val3   "',
+            'ASSERTVAR4="0" # empty looking value',
+            'ASSERTVAR5=#foo',
+            "ASSERTVAR6=\"val1\nval2\"",
+            "ASSERTVAR7=\"\nval3\" #",
+            "ASSERTVAR8=\"val3\n\"",
+            "ASSERTVAR9=\"\n\"",
+        ];
+
+        $this->assertSame($expected, Lines::process($content));
+    }
+}

--- a/tests/Dotenv/ParserTest.php
+++ b/tests/Dotenv/ParserTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Dotenv\Parser;
+use PHPUnit\Framework\TestCase;
+
+class ParserTest extends TestCase
+{
+    public function testBasicParse()
+    {
+        $this->assertSame(['FOO', 'BAR'], Parser::parse('FOO=BAR'));
+    }
+
+    public function testQuotesParse()
+    {
+        $this->assertSame(['FOO', "BAR  \n"], Parser::parse("FOO=\"BAR  \n\""));
+    }
+
+    public function testExportParse()
+    {
+        $this->assertSame(['FOO', 'bar baz'], Parser::parse('export FOO="bar baz"'));
+    }
+}


### PR DESCRIPTION
Loader was starting to do a lot of things, especially after adding multiline support, so I've pulled out parsing of the file into entries into one class (`Lines`), and handing the parsing of an entry in (`Parser`).

Finally, I've changed the `load` method so that it returns the actual environment variables as an associative array, rather than the raw lines from the file.