### PR TITLE
Support direct loading with a string 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.1-dev"
+            "dev-master": "3.2-dev"
         }
     }
 }

--- a/src/Environment/Adapter/ArrayAdapter.php
+++ b/src/Environment/Adapter/ArrayAdapter.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Dotenv\Environment\Adapter;
+
+use PhpOption\None;
+use PhpOption\Some;
+
+class ArrayAdapter implements AdapterInterface
+{
+    /**
+     * The variables and their values.
+     *
+     * @return array<string|null>
+     */
+    private $variables = [];
+
+    /**
+     * Determines if the adapter is supported.
+     *
+     * @return bool
+     */
+    public function isSupported()
+    {
+        return true;
+    }
+
+    /**
+     * Get an environment variable, if it exists.
+     *
+     * @param string $name
+     *
+     * @return \PhpOption\Option
+     */
+    public function get($name)
+    {
+        if (array_key_exists($name, $this->variables)) {
+            return Some::create($this->variables[$name]);
+        }
+
+        return None::create();
+    }
+
+    /**
+     * Set an environment variable.
+     *
+     * @param string      $name
+     * @param string|null $value
+     *
+     * @return void
+     */
+    public function set($name, $value = null)
+    {
+        $this->variables[$name] = $value;
+    }
+
+    /**
+     * Clear an environment variable.
+     *
+     * @param string $name
+     *
+     * @return void
+     */
+    public function clear($name)
+    {
+        unset($this->variables[$name]);
+    }
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -81,7 +81,7 @@ class Loader
     /**
      * Load the environment file from disk.
      *
-     * @throws \Dotenv\Exception\InvalidFileException
+     * @throws \Dotenv\Exception\InvalidPathException|\Dotenv\Exception\InvalidFileException
      *
      * @return array<string|null>
      */
@@ -97,7 +97,7 @@ class Loader
      *
      * @param string $content
      *
-     * @throws \Dotenv\Exception\InvalidPathException|\Dotenv\Exception\InvalidFileException
+     * @throws \Dotenv\Exception\InvalidFileException
      *
      * @return array<string|null>
      */

--- a/tests/Dotenv/LinesTest.php
+++ b/tests/Dotenv/LinesTest.php
@@ -5,28 +5,9 @@ use PHPUnit\Framework\TestCase;
 
 class LinesTest extends TestCase
 {
-    /**
-     * @var string|false
-     */
-    protected $autodetect;
-
-    public function setUp()
-    {
-        $this->autodetect = ini_get('auto_detect_line_endings');
-        ini_set('auto_detect_line_endings', '1');
-    }
-
-    public function tearDown()
-    {
-        ini_set('auto_detect_line_endings', $this->autodetect);
-    }
-
     public function testProcess()
     {
-        $content = file(
-            dirname(__DIR__).'/fixtures/env/assertions.env',
-            FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
-        );
+        $content = file_get_contents(dirname(__DIR__).'/fixtures/env/assertions.env');
 
         $expected = [
             'ASSERTVAR1=val1',
@@ -40,6 +21,6 @@ class LinesTest extends TestCase
             "ASSERTVAR9=\"\n\"",
         ];
 
-        $this->assertSame($expected, Lines::process($content));
+        $this->assertSame($expected, Lines::process(preg_split("/(\r\n|\n|\r)/", $content)));
     }
 }

--- a/tests/Dotenv/LoaderTest.php
+++ b/tests/Dotenv/LoaderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Dotenv\Environment\Adapter\ArrayAdapter;
 use Dotenv\Environment\DotenvFactory;
 use Dotenv\Loader;
 use PHPUnit\Framework\TestCase;
@@ -123,5 +124,25 @@ class LoaderTest extends TestCase
         $loader = (new Loader(["{$this->folder}/BAD1", "{$this->folder}/.env"], new DotenvFactory(), false));
 
         $this->assertCount(4, $loader->load());
+    }
+
+    public function testLoaderWithNoAdapters()
+    {
+        $loader = (new Loader([], new DotenvFactory([])));
+
+        $content = "NVAR1=\"Hello\"\nNVAR2=\"World!\"\nNVAR3=\"{\$NVAR1} {\$NVAR2}\"\nNVAR4=\"\${NVAR1} \${NVAR2}\"";
+        $expected = ['NVAR1' => 'Hello', 'NVAR2' => 'World!', 'NVAR3' => '{$NVAR1} {$NVAR2}', 'NVAR4' => '${NVAR1} ${NVAR2}'];
+
+        $this->assertSame($expected, $loader->loadDirect($content));
+    }
+
+    public function testLoaderWithArrayAdapter()
+    {
+        $loader = (new Loader([], new DotenvFactory([new ArrayAdapter()])));
+
+        $content = "NVAR1=\"Hello\"\nNVAR2=\"World!\"\nNVAR3=\"{\$NVAR1} {\$NVAR2}\"\nNVAR4=\"\${NVAR1} \${NVAR2}\"";
+        $expected = ['NVAR1' => 'Hello', 'NVAR2' => 'World!', 'NVAR3' => '{$NVAR1} {$NVAR2}', 'NVAR4' => 'Hello World!'];
+
+        $this->assertSame($expected, $loader->loadDirect($content));
     }
 }

--- a/tests/fixtures/env/assertions.env
+++ b/tests/fixtures/env/assertions.env
@@ -1,6 +1,7 @@
 ASSERTVAR1=val1
 
 ASSERTVAR2=""
+
 ASSERTVAR3="val3   "
 ASSERTVAR4="0" # empty looking value
 ASSERTVAR5=#foo
@@ -8,6 +9,8 @@ ASSERTVAR6="val1
 val2"
 ASSERTVAR7="
 val3" #
+
+
 ASSERTVAR8="val3
 "
 ASSERTVAR9="


### PR DESCRIPTION
Example usage, where `$content` is a string containing the content of some `.env` file:

```php
<?php

use Dotenv\Environment\Adapter\ArrayAdapter;
use Dotenv\Environment\DotenvFactory;
use Dotenv\Loader;

$loader = (new Loader([], new DotenvFactory([new ArrayAdapter()])));

$variables = $loader->loadDirect($content));
```

Why do we need the array adapter? This allows nested variables to work correctly, but avoid mutating your actual environment.'