### PR TITLE
[2.6] Backport parser fixes from 3.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9"
+        "php": ">=5.3.9",
+        "symfony/polyfill-ctype": "^1.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.0"

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Dotenv;
+
+use Dotenv\Exception\InvalidFileException;
+
+class Parser
+{
+    const INITIAL_STATE = 0;
+    const UNQUOTED_STATE = 1;
+    const QUOTED_STATE = 2;
+    const ESCAPE_STATE = 3;
+    const WHITESPACE_STATE = 4;
+    const COMMENT_STATE = 5;
+
+    /**
+     * Parse the given variable name.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public static function parseName($name)
+    {
+        return trim(str_replace(array('export ', '\'', '"'), '', $name));
+    }
+
+    /**
+     * Parse the given variable value.
+     *
+     * @param string $value
+      *
+     * @throws \Dotenv\Exception\InvalidFileException
+     *
+     * @return string
+     */
+    public static function parseValue($value)
+    {
+        $data = array_reduce(str_split($value), function ($data, $char) use ($value) {
+            switch ($data[1]) {
+                case self::INITIAL_STATE:
+                    if ($char === '"') {
+                        return array($data[0], self::QUOTED_STATE);
+                    } else {
+                        return array($data[0].$char, self::UNQUOTED_STATE);
+                    }
+                case self::UNQUOTED_STATE:
+                    if ($char === '#') {
+                        return array($data[0], self::COMMENT_STATE);
+                    } elseif (ctype_space($char)) {
+                        return array($data[0], self::WHITESPACE_STATE);
+                    } else {
+                        return array($data[0].$char, self::UNQUOTED_STATE);
+                    }
+                case self::QUOTED_STATE:
+                    if ($char === '"') {
+                        return array($data[0], self::WHITESPACE_STATE);
+                    } elseif ($char === '\\') {
+                        return array($data[0], self::ESCAPE_STATE);
+                    } else {
+                        return array($data[0].$char, self::QUOTED_STATE);
+                    }
+                case self::ESCAPE_STATE:
+                    if ($char === '"' || $char === '\\') {
+                        return array($data[0].$char, self::QUOTED_STATE);
+                    } else {
+                        return array($data[0].'\\'.$char, self::QUOTED_STATE);
+                    }
+                case self::WHITESPACE_STATE:
+                    if ($char === '#') {
+                        return array($data[0], self::COMMENT_STATE);
+                    } elseif (!ctype_space($char)) {
+                        if ($data[0] !== '' && $data[0][0] === '#') {
+                            return array('', self::COMMENT_STATE);
+                        } else {
+                            throw new InvalidFileException('Dotenv values containing spaces must be surrounded by quotes.');
+                        }
+                    } else {
+                        return array($data[0], self::WHITESPACE_STATE);
+                    }
+                case self::COMMENT_STATE:
+                    return array($data[0], self::COMMENT_STATE);
+            }
+        }, array('', self::INITIAL_STATE));
+
+        return trim($data[0]);
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -38,50 +38,50 @@ class Parser
     {
         $data = array_reduce(str_split($value), function ($data, $char) use ($value) {
             switch ($data[1]) {
-                case self::INITIAL_STATE:
+                case Parser::INITIAL_STATE:
                     if ($char === '"') {
-                        return array($data[0], self::QUOTED_STATE);
+                        return array($data[0], Parser::QUOTED_STATE);
                     } else {
-                        return array($data[0].$char, self::UNQUOTED_STATE);
+                        return array($data[0].$char, Parser::UNQUOTED_STATE);
                     }
-                case self::UNQUOTED_STATE:
+                case Parser::UNQUOTED_STATE:
                     if ($char === '#') {
-                        return array($data[0], self::COMMENT_STATE);
+                        return array($data[0], Parser::COMMENT_STATE);
                     } elseif (ctype_space($char)) {
-                        return array($data[0], self::WHITESPACE_STATE);
+                        return array($data[0], Parser::WHITESPACE_STATE);
                     } else {
-                        return array($data[0].$char, self::UNQUOTED_STATE);
+                        return array($data[0].$char, Parser::UNQUOTED_STATE);
                     }
-                case self::QUOTED_STATE:
+                case Parser::QUOTED_STATE:
                     if ($char === '"') {
-                        return array($data[0], self::WHITESPACE_STATE);
+                        return array($data[0], Parser::WHITESPACE_STATE);
                     } elseif ($char === '\\') {
-                        return array($data[0], self::ESCAPE_STATE);
+                        return array($data[0], Parser::ESCAPE_STATE);
                     } else {
-                        return array($data[0].$char, self::QUOTED_STATE);
+                        return array($data[0].$char, Parser::QUOTED_STATE);
                     }
-                case self::ESCAPE_STATE:
+                case Parser::ESCAPE_STATE:
                     if ($char === '"' || $char === '\\') {
-                        return array($data[0].$char, self::QUOTED_STATE);
+                        return array($data[0].$char, Parser::QUOTED_STATE);
                     } else {
-                        return array($data[0].'\\'.$char, self::QUOTED_STATE);
+                        return array($data[0].'\\'.$char, Parser::QUOTED_STATE);
                     }
-                case self::WHITESPACE_STATE:
+                case Parser::WHITESPACE_STATE:
                     if ($char === '#') {
-                        return array($data[0], self::COMMENT_STATE);
+                        return array($data[0], Parser::COMMENT_STATE);
                     } elseif (!ctype_space($char)) {
                         if ($data[0] !== '' && $data[0][0] === '#') {
-                            return array('', self::COMMENT_STATE);
+                            return array('', Parser::COMMENT_STATE);
                         } else {
                             throw new InvalidFileException('Dotenv values containing spaces must be surrounded by quotes.');
                         }
                     } else {
-                        return array($data[0], self::WHITESPACE_STATE);
+                        return array($data[0], Parser::WHITESPACE_STATE);
                     }
-                case self::COMMENT_STATE:
-                    return array($data[0], self::COMMENT_STATE);
+                case Parser::COMMENT_STATE:
+                    return array($data[0], Parser::COMMENT_STATE);
             }
-        }, array('', self::INITIAL_STATE));
+        }, array('', Parser::INITIAL_STATE));
 
         return trim($data[0]);
     }

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -65,6 +65,7 @@ class DotenvTest extends TestCase
         $this->assertEmpty(getenv('QNULL'));
         $this->assertSame('pgsql:host=localhost;dbname=test', getenv('QEQUALS'));
         $this->assertSame('test some escaped characters like a quote (") or maybe a backslash (\\)', getenv('QESCAPED'));
+        $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('QSLASH'));
     }
 
     public function testLargeDotenvLoadsEnvironmentVars()

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -65,7 +65,8 @@ class DotenvTest extends TestCase
         $this->assertEmpty(getenv('QNULL'));
         $this->assertSame('pgsql:host=localhost;dbname=test', getenv('QEQUALS'));
         $this->assertSame('test some escaped characters like a quote (") or maybe a backslash (\\)', getenv('QESCAPED'));
-        $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('QSLASH'));
+        $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('QSLASH1'));
+        $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('QSLASH2'));
     }
 
     public function testLargeDotenvLoadsEnvironmentVars()

--- a/tests/fixtures/env/quoted.env
+++ b/tests/fixtures/env/quoted.env
@@ -7,3 +7,4 @@ QNULL=""
 QWHITESPACE = "no space"
 
 QESCAPED="test some escaped characters like a quote (\") or maybe a backslash (\\)"
+QSLASH="iiiiviiiixiiiiviiii\n"

--- a/tests/fixtures/env/quoted.env
+++ b/tests/fixtures/env/quoted.env
@@ -7,4 +7,5 @@ QNULL=""
 QWHITESPACE = "no space"
 
 QESCAPED="test some escaped characters like a quote (\") or maybe a backslash (\\)"
-QSLASH="iiiiviiiixiiiiviiii\n"
+QSLASH1="iiiiviiiixiiiiviiii\n"
+QSLASH2="iiiiviiiixiiiiviiii\\n"


### PR DESCRIPTION
Note that this DOES NOT implement identical parsing to in 3.x. Every attempt has been made to ensure this backport behaves exactly as in 2.5.x, and also allows cases that previously crashed in 2.5.x, being as lenient as possible (where identical case in 3.3.x will hard fail).

This fixes the example from https://github.com/vlucas/phpdotenv/pull/332.

---

How does this differ from the parsing in 3.3+:

1. Unquoted values without spaces starting with a hash are considered to be comments in 3.3+ but in 2.x are treated as literal values.
2. Invalid escape sequences within quoted values in 2.5 fail silently, in 2.6 are permitted, and in 3.x will fail loudly (with a proper error message in 3.3+).

---

### Example 1:

```
FOO=#foo
```

2.5: parses as `#foo`
2.6: parses as `#foo`
3.2: parses as `#foo` (considered a bug in the 3.x series)
3.3: parses as the empty string

### Example 2:

```
FOO=#foo bar
```

2.5: parses as the empty string
2.6: parses as the empty string
3.2: parses as the empty string
3.3: parses as the empty string

### Example 3:

```
FOO="#foo"
```

2.5: parses as `#foo`
2.6: parses as `#foo`
3.2: parses as `#foo`
3.3: parses as `#foo`

### Example 4:

```
FOO="iiiiviiiixiiiiviiii\n"
```

2.5: fails silently
2.6: parses as `iiiiviiiixiiiiviiii\n`
3.2: fails with an obscure preg error
3.3: fails saying invalid escape sequence

### Example 5:

```
FOO="iiiiviiiixiiiiviiii\\n"
```

2.5: parses as `iiiiviiiixiiiiviiii\n`
2.6: parses as `iiiiviiiixiiiiviiii\n`
3.2: parses as `iiiiviiiixiiiiviiii\n`
3.3: parses as `iiiiviiiixiiiiviiii\n`
