### PR TITLE
[2.6] Fixed parsing regressions

### DIFF
--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -64,9 +64,14 @@ class DotenvTest extends TestCase
         $this->assertSame('with spaces', getenv('QSPACED'));
         $this->assertEmpty(getenv('QNULL'));
         $this->assertSame('pgsql:host=localhost;dbname=test', getenv('QEQUALS'));
+
         $this->assertSame('test some escaped characters like a quote (") or maybe a backslash (\\)', getenv('QESCAPED'));
         $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('QSLASH1'));
         $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('QSLASH2'));
+
+        $this->assertSame('test some escaped characters like a quote (\') or maybe a backslash (\\)', getenv('SQESCAPED'));
+        $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('SQSLASH1'));
+        $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('SQSLASH2'));
     }
 
     public function testLargeDotenvLoadsEnvironmentVars()
@@ -261,6 +266,9 @@ class DotenvTest extends TestCase
         $this->assertSame('jdgEB4{QgEC]HL))&GcXxokB+wqoN+j>xkV7K?m$r', getenv('SPVAR3'));
         $this->assertSame('22222:22#2^{', getenv('SPVAR4'));
         $this->assertSame('test some escaped characters like a quote " or maybe a backslash \\', getenv('SPVAR5'));
+        $this->assertSame('secret!@#', getenv('SPVAR6'));
+        $this->assertSame('secret!@#', getenv('SPVAR7'));
+        $this->assertSame('secret!@#', getenv('SPVAR8'));
     }
 
     public function testDotenvAssertions()

--- a/tests/fixtures/env/quoted.env
+++ b/tests/fixtures/env/quoted.env
@@ -9,3 +9,7 @@ QWHITESPACE = "no space"
 QESCAPED="test some escaped characters like a quote (\") or maybe a backslash (\\)"
 QSLASH1="iiiiviiiixiiiiviiii\n"
 QSLASH2="iiiiviiiixiiiiviiii\\n"
+
+SQESCAPED='test some escaped characters like a quote (\') or maybe a backslash (\\)'
+SQSLASH1='iiiiviiiixiiiiviiii\n'
+SQSLASH2='iiiiviiiixiiiiviiii\\n'

--- a/tests/fixtures/env/specialchars.env
+++ b/tests/fixtures/env/specialchars.env
@@ -3,3 +3,6 @@ SPVAR2="?BUty3koaV3%GA*hMAwH}B"
 SPVAR3="jdgEB4{QgEC]HL))&GcXxokB+wqoN+j>xkV7K?m$r"
 SPVAR4="22222:22#2^{"
 SPVAR5="test some escaped characters like a quote \" or maybe a backslash \\" # not escaped
+SPVAR6=secret!@#
+SPVAR7='secret!@#'
+SPVAR8="secret!@#"


### PR DESCRIPTION
This:

1. Restores single-quoted value parsing and adds tests
2. Restores the comment parsing behaviour from 2.5.x

---

Closes #336. Closes #337.
// cc @makersm, @zhouzyc, @robtesch, @erikscheepers, @mbrodala, @wolfy-j