### PR TITLE
[3.3] Fixed parsing regressions

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -108,7 +108,7 @@ class Parser
         return array_reduce(str_split($value), function ($data, $char) use ($value) {
             switch ($data[1]) {
                 case self::INITIAL_STATE:
-                    if ($char === '"') {
+                    if ($char === '"' || $char === '\'') {
                         return [$data[0], self::QUOTED_STATE];
                     } elseif ($char === '#') {
                         return [$data[0], self::COMMENT_STATE];
@@ -124,7 +124,7 @@ class Parser
                         return [$data[0].$char, self::UNQUOTED_STATE];
                     }
                 case self::QUOTED_STATE:
-                    if ($char === '"') {
+                    if ($char === $value[0]) {
                         return [$data[0], self::WHITESPACE_STATE];
                     } elseif ($char === '\\') {
                         return [$data[0], self::ESCAPE_STATE];
@@ -132,7 +132,7 @@ class Parser
                         return [$data[0].$char, self::QUOTED_STATE];
                     }
                 case self::ESCAPE_STATE:
-                    if ($char === '"' || $char === '\\') {
+                    if ($char === $value[0] || $char === '\\') {
                         return [$data[0].$char, self::QUOTED_STATE];
                     } else {
                         throw new InvalidFileException(

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -84,9 +84,13 @@ class DotenvTest extends TestCase
         $this->assertSame('baz', getenv('QBAR'));
         $this->assertSame('with spaces', getenv('QSPACED'));
         $this->assertEmpty(getenv('QNULL'));
+
         $this->assertSame('pgsql:host=localhost;dbname=test', getenv('QEQUALS'));
         $this->assertSame('test some escaped characters like a quote (") or maybe a backslash (\\)', getenv('QESCAPED'));
         $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('QSLASH'));
+
+        $this->assertSame('test some escaped characters like a quote (\') or maybe a backslash (\\)', getenv('SQESCAPED'));
+        $this->assertSame('iiiiviiiixiiiiviiii\\n', getenv('SQSLASH'));
     }
 
     public function testLargeDotenvLoadsEnvironmentVars()
@@ -274,6 +278,9 @@ class DotenvTest extends TestCase
         $this->assertSame('jdgEB4{QgEC]HL))&GcXxokB+wqoN+j>xkV7K?m$r', getenv('SPVAR3'));
         $this->assertSame('22222:22#2^{', getenv('SPVAR4'));
         $this->assertSame('test some escaped characters like a quote " or maybe a backslash \\', getenv('SPVAR5'));
+        $this->assertSame('secret!@', getenv('SPVAR6'));
+        $this->assertSame('secret!@#', getenv('SPVAR7'));
+        $this->assertSame('secret!@#', getenv('SPVAR8'));
     }
 
     public function testMutlilineLoading()

--- a/tests/Dotenv/ParserTest.php
+++ b/tests/Dotenv/ParserTest.php
@@ -64,8 +64,17 @@ class ParserTest extends TestCase
      * @expectedException \Dotenv\Exception\InvalidFileException
      * @expectedExceptionMessage Failed to parse dotenv file due to an unexpected escape sequence. Failed at ["iiiiviiiixiiiiviiii\n"].
      */
-    public function testParserEscaping()
+    public function testParserEscapingDouble()
     {
         Parser::parse('FOO_BAD="iiiiviiiixiiiiviiii\\n"');
+    }
+
+    /**
+     * @expectedException \Dotenv\Exception\InvalidFileException
+     * @expectedExceptionMessage Failed to parse dotenv file due to an unexpected escape sequence. Failed at ['iiiiviiiixiiiiviiii\n'].
+     */
+    public function testParserEscapingSingle()
+    {
+        Parser::parse('FOO_BAD=\'iiiiviiiixiiiiviiii\\n\'');
     }
 }

--- a/tests/fixtures/env/quoted.env
+++ b/tests/fixtures/env/quoted.env
@@ -8,3 +8,6 @@ QWHITESPACE = "no space"
 
 QESCAPED="test some escaped characters like a quote (\") or maybe a backslash (\\)"
 QSLASH="iiiiviiiixiiiiviiii\\n"
+
+SQESCAPED='test some escaped characters like a quote (\') or maybe a backslash (\\)'
+SQSLASH='iiiiviiiixiiiiviiii\\n'

--- a/tests/fixtures/env/specialchars.env
+++ b/tests/fixtures/env/specialchars.env
@@ -3,3 +3,6 @@ SPVAR2="?BUty3koaV3%GA*hMAwH}B"
 SPVAR3="jdgEB4{QgEC]HL))&GcXxokB+wqoN+j>xkV7K?m$r"
 SPVAR4="22222:22#2^{"
 SPVAR5="test some escaped characters like a quote \" or maybe a backslash \\" # not escaped
+SPVAR6=secret!@#
+SPVAR7='secret!@#'
+SPVAR8="secret!@#"


### PR DESCRIPTION
Note that the comment parsing behaviour is different in 3.3.x to that in 2.6.x, so the unquoted hash at the end of a string will be treated as the start of a comment in 3.3.x, but as a literal in 2.6.x