### PR TITLE
Declare the error text variable in one place and utilise it

### DIFF
--- a/src/Regex/Regex.php
+++ b/src/Regex/Regex.php
@@ -72,7 +72,8 @@ class Regex
             })
             ->map(function (array $consts) {
                 return array_filter($consts['pcre'], function ($msg) {
-                    return substr($msg, -6) === '_ERROR';
+                    $errorText = '_ERROR';
+                    return substr($msg, strlen($errorText) * -1) === $errorText;
                 }, ARRAY_FILTER_USE_KEY);
             })
             ->flatMap(function (array $errors) use ($code) {


### PR DESCRIPTION
This means that it's only declared in one place and we don't have to switch both values.