### PR TITLE
Handle \n in quotes strings

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -134,6 +134,8 @@ class Parser
                 case self::ESCAPE_STATE:
                     if ($char === $value[0] || $char === '\\') {
                         return [$data[0].$char, self::QUOTED_STATE];
+                    } elseif (in_array($char, ['n', 'r'], true)) {
+                        return [$data[0].stripcslashes('\\' . $char), self::QUOTED_STATE];
                     } else {
                         throw new InvalidFileException(
                             self::getErrorMessage('an unexpected escape sequence', $value)

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -296,6 +296,9 @@ class DotenvTest extends TestCase
         $dotenv = Dotenv::create($this->fixturesFolder, 'multiline.env');
         $dotenv->load();
         $this->assertSame("test\n     test\"test\"\n     test", getenv('TEST'));
+        $this->assertSame("test\ntest", getenv('TEST_ND'));
+        $this->assertSame("test\ntest", getenv('TEST_NS'));
+
         $this->assertSame('https://vision.googleapis.com/v1/images:annotate?key=', getenv('TEST_EQD'));
         $this->assertSame('https://vision.googleapis.com/v1/images:annotate?key=', getenv('TEST_EQS'));
     }

--- a/tests/Dotenv/LinesTest.php
+++ b/tests/Dotenv/LinesTest.php
@@ -30,6 +30,8 @@ class LinesTest extends TestCase
 
         $expected = [
             "TEST=\"test\n     test\\\"test\\\"\n     test\"",
+            "TEST_ND=\"test\\ntest\"",
+            'TEST_NS=\'test\\ntest\'',
             'TEST_EQD="https://vision.googleapis.com/v1/images:annotate?key="',
             'TEST_EQS=\'https://vision.googleapis.com/v1/images:annotate?key=\'',
         ];

--- a/tests/Dotenv/ParserTest.php
+++ b/tests/Dotenv/ParserTest.php
@@ -62,19 +62,19 @@ class ParserTest extends TestCase
 
     /**
      * @expectedException \Dotenv\Exception\InvalidFileException
-     * @expectedExceptionMessage Failed to parse dotenv file due to an unexpected escape sequence. Failed at ["iiiiviiiixiiiiviiii\n"].
+     * @expectedExceptionMessage Failed to parse dotenv file due to an unexpected escape sequence. Failed at ["iiiiviiiixiiiiviiii\a"].
      */
     public function testParserEscapingDouble()
     {
-        Parser::parse('FOO_BAD="iiiiviiiixiiiiviiii\\n"');
+        Parser::parse('FOO_BAD="iiiiviiiixiiiiviiii\\a"');
     }
 
     /**
      * @expectedException \Dotenv\Exception\InvalidFileException
-     * @expectedExceptionMessage Failed to parse dotenv file due to an unexpected escape sequence. Failed at ['iiiiviiiixiiiiviiii\n'].
+     * @expectedExceptionMessage Failed to parse dotenv file due to an unexpected escape sequence. Failed at ['iiiiviiiixiiiiviiii\a'].
      */
     public function testParserEscapingSingle()
     {
-        Parser::parse('FOO_BAD=\'iiiiviiiixiiiiviiii\\n\'');
+        Parser::parse('FOO_BAD=\'iiiiviiiixiiiiviiii\\a\'');
     }
 }

--- a/tests/fixtures/env/multiline.env
+++ b/tests/fixtures/env/multiline.env
@@ -2,5 +2,8 @@ TEST="test
      test\"test\"
      test"
 
+TEST_ND="test\ntest"
+TEST_NS='test\ntest'
+
 TEST_EQD="https://vision.googleapis.com/v1/images:annotate?key="
 TEST_EQS='https://vision.googleapis.com/v1/images:annotate?key='


### PR DESCRIPTION
Background: I have a `.env` file that I also share with Docker. Docker doesn't handle newlines directly, so I escape them like so:

    VARIABLE="Line1\nLine2"

I expected this to also work with phpdotenv, so I was caught by surprise when it didn't. Is there a compelling reason not to support it, or can support be added?

I'm attaching a failing test and also a patch that makes the test go green. In my implementation, I created an array of allowed characters (`['n', 'r']`), so that it can be easily expanded if more characters should also be allowed (like `\t`). If you don't like the implementation, please let me know how it could be improved, or just change it.

Note: I guess it could be argued that `\n` should not be expanded when using single quotes (the `TEST_NS` value in the `multiline.env` test). But as long as the parser currently uses the same state (QUOTED_STATE) for both single and double quotes, it seems hard to distinguish without a larger rewrite)
