### PR TITLE
Allow PHPUnit 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/polyfill-ctype": "^1.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0"
+        "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Dropping PHPUnit 4 and supporting 8 and 9 can only happen once we drop support for PHP 5.4 and 5.5. For now, I won't do this, but if this becomes necessary to support PHP 8, I will.