### PR TITLE
updated Parser class to support escaping $sign

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -134,7 +134,7 @@ class Parser
                 case self::ESCAPE_STATE:
                     if ($char === $value[0] || $char === '\\') {
                         return [$data[0].$char, self::QUOTED_STATE];
-                    } elseif (in_array($char, ['f', 'n', 'r', 't', 'v'], true)) {
+                    } elseif (in_array($char, ['f', 'n', 'r', 't', 'v', '$'], true)) {
                         return [$data[0].stripcslashes('\\' . $char), self::QUOTED_STATE];
                     } else {
                         throw new InvalidFileException(


### PR DESCRIPTION
Parser raises a fatal error if env value contains a dollar sign escaping like '3mypas\$word'.
added the dollar sign to escaping list at the case ESCAPE_STATE fixed the issue. 

`Fatal error: Uncaught Dotenv\Exception\InvalidFileException: Failed to parse dotenv file due to an 
unexpected escape sequence. Failed at ['3mypas\$word'].
`