### PR TITLE
Fix create method return type

### DIFF
--- a/src/Repository/RepositoryBuilder.php
+++ b/src/Repository/RepositoryBuilder.php
@@ -50,7 +50,7 @@ class RepositoryBuilder
     /**
      * Create a new repository builder instance.
      *
-     * @return void
+     * @return \Dotenv\Repository\RepositoryBuilder
      */
     public static function create()
     {


### PR DESCRIPTION
Use correct return type for `RepositoryBuilder::create` method