### PR TITLE
[4.1] Support multiple file names and disabling short circuit file loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0-dev"
+            "dev-master": "4.1-dev"
         }
     }
 }

--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -111,7 +111,7 @@ class Dotenv
      *
      * @throws \Dotenv\Exception\InvalidPathException|\Dotenv\Exception\InvalidFileException
      *
-     * @return array<string|null>
+     * @return array<string,string|null>
      */
     public function load()
     {
@@ -123,7 +123,7 @@ class Dotenv
      *
      * @throws \Dotenv\Exception\InvalidFileException
      *
-     * @return array<string|null>
+     * @return array<string,string|null>
      */
     public function safeLoad()
     {

--- a/src/File/Paths.php
+++ b/src/File/Paths.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Dotenv\File;
+
+use PhpOption\Option;
+
+class Paths
+{
+    /**
+     * Returns the full paths to the files.
+     *
+     * @param string[] $paths
+     * @param string[] $names
+     *
+     * @return string[]
+     */
+    public static function filePaths(array $paths, array $names)
+    {
+        $files = [];
+
+        foreach ($paths as $path) {
+            foreach ($names as $name) {
+                $files[] = rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$name;
+            }
+        }
+
+        return $files;
+    }
+}

--- a/src/File/Reader.php
+++ b/src/File/Reader.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Dotenv\File;
+
+use PhpOption\Option;
+
+class Reader
+{
+    /**
+     * Read the file(s), and return their raw content.
+     *
+     * We provide the file path as the key, and its content as the value. If
+     * short circuit mode is enabled, then the returned array with have length
+     * at most one. File paths that couldn't be read are omitted entirely.
+     *
+     * @param string[] $filePaths
+     * @param bool     $shortCircuit
+     *
+     * @return array<string,string>
+     */
+    public static function read(array $filePaths, $shortCircuit = true)
+    {
+        $output = [];
+
+        foreach ($filePaths as $filePath) {
+            $content = self::readFromFile($filePath);
+            if ($content->isDefined()) {
+                $output[$filePath] = $content->get();
+                if ($shortCircuit) {
+                    break;
+                }
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Read the given file.
+     *
+     * @param string $filePath
+     *
+     * @return \PhpOption\Option
+     */
+    private static function readFromFile($filePath)
+    {
+        $content = @file_get_contents($filePath);
+
+        return Option::fromValue($content, false);
+    }
+}

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -16,7 +16,7 @@ class Loader implements LoaderInterface
      *
      * @throws \Dotenv\Exception\InvalidFileException
      *
-     * @return array<string|null>
+     * @return array<string,string|null>
      */
     public function load(RepositoryInterface $repository, $content)
     {
@@ -37,7 +37,7 @@ class Loader implements LoaderInterface
      *
      * @throws \Dotenv\Exception\InvalidFileException
      *
-     * @return array<string|null>
+     * @return array<string.string|null>
      */
     private static function processEntries(RepositoryInterface $repository, array $entries)
     {

--- a/src/Loader/LoaderInterface.php
+++ b/src/Loader/LoaderInterface.php
@@ -14,7 +14,7 @@ interface LoaderInterface
      *
      * @throws \Dotenv\Exception\InvalidFileException
      *
-     * @return array<string|null>
+     * @return array<string,string|null>
      */
     public function load(RepositoryInterface $repository, $content);
 }

--- a/src/Repository/Adapter/ArrayAdapter.php
+++ b/src/Repository/Adapter/ArrayAdapter.php
@@ -10,7 +10,7 @@ class ArrayAdapter implements AvailabilityInterface, ReaderInterface, WriterInte
     /**
      * The variables and their values.
      *
-     * @return array<string|null>
+     * @return array<string,string|null>
      */
     private $variables = [];
 

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -70,6 +70,26 @@ class DotenvTest extends TestCase
         $this->assertEmpty(getenv('NULL'));
     }
 
+    public function testDotenvLoadsEnvironmentVarsMultipleNotShortCircuitMode()
+    {
+        $dotenv = Dotenv::createImmutable($this->folder, ['.env', 'example.env']);
+
+        $this->assertSame(
+            ['FOO' => 'bar', 'BAR' => 'baz', 'SPACED' => 'with spaces', 'NULL' => ''],
+            $dotenv->load()
+        );
+    }
+
+    public function testDotenvLoadsEnvironmentVarsMultipleWithShortCircuitMode()
+    {
+        $dotenv = Dotenv::createImmutable($this->folder, ['.env', 'example.env'], false);
+
+        $this->assertSame(
+            ['FOO' => 'bar', 'BAR' => 'baz', 'SPACED' => 'with spaces', 'NULL' => '', 'EG' => 'example'],
+            $dotenv->load()
+        );
+    }
+
     public function testCommentedDotenvLoadsEnvironmentVars()
     {
         $dotenv = Dotenv::createImmutable($this->folder, 'commented.env');

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -70,6 +70,31 @@ class DotenvTest extends TestCase
         $this->assertEmpty(getenv('NULL'));
     }
 
+    public function testDotenvReadsEnvironmentVarsMultipleNotShortCircuitMode()
+    {
+        $dotenv = Dotenv::createImmutable($this->folder, ['.env', 'example.env']);
+
+        $this->assertSame(
+            [
+                $this->folder.DIRECTORY_SEPARATOR.'.env' => "FOO=bar\nBAR=baz\nSPACED=\"with spaces\"\n\nNULL=\n",
+            ],
+            $dotenv->read()
+        );
+    }
+
+    public function testDotenvReadsEnvironmentVarsMultipleWithShortCircuitMode()
+    {
+        $dotenv = Dotenv::createImmutable($this->folder, ['.env', 'example.env'], false);
+
+        $this->assertSame(
+            [
+                $this->folder.DIRECTORY_SEPARATOR.'.env' => "FOO=bar\nBAR=baz\nSPACED=\"with spaces\"\n\nNULL=\n",
+                $this->folder.DIRECTORY_SEPARATOR.'example.env' => "EG=\"example\"\n",
+            ],
+            $dotenv->read()
+        );
+    }
+
     public function testDotenvLoadsEnvironmentVarsMultipleNotShortCircuitMode()
     {
         $dotenv = Dotenv::createImmutable($this->folder, ['.env', 'example.env']);

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -51,6 +51,12 @@ class DotenvTest extends TestCase
         $this->assertCount(4, $dotenv->load());
     }
 
+    public function testDotenvTriesPathsToSafeLoad()
+    {
+        $dotenv = Dotenv::createImmutable([__DIR__, $this->folder]);
+        $this->assertCount(4, $dotenv->safeLoad());
+    }
+
     public function testDotenvSkipsLoadingIfFileIsMissing()
     {
         $dotenv = Dotenv::createImmutable(__DIR__);
@@ -68,31 +74,6 @@ class DotenvTest extends TestCase
         $this->assertSame('baz', getenv('BAR'));
         $this->assertSame('with spaces', getenv('SPACED'));
         $this->assertEmpty(getenv('NULL'));
-    }
-
-    public function testDotenvReadsEnvironmentVarsMultipleNotShortCircuitMode()
-    {
-        $dotenv = Dotenv::createImmutable($this->folder, ['.env', 'example.env']);
-
-        $this->assertSame(
-            [
-                $this->folder.DIRECTORY_SEPARATOR.'.env' => "FOO=bar\nBAR=baz\nSPACED=\"with spaces\"\n\nNULL=\n",
-            ],
-            $dotenv->read()
-        );
-    }
-
-    public function testDotenvReadsEnvironmentVarsMultipleWithShortCircuitMode()
-    {
-        $dotenv = Dotenv::createImmutable($this->folder, ['.env', 'example.env'], false);
-
-        $this->assertSame(
-            [
-                $this->folder.DIRECTORY_SEPARATOR.'.env' => "FOO=bar\nBAR=baz\nSPACED=\"with spaces\"\n\nNULL=\n",
-                $this->folder.DIRECTORY_SEPARATOR.'example.env' => "EG=\"example\"\n",
-            ],
-            $dotenv->read()
-        );
     }
 
     public function testDotenvLoadsEnvironmentVarsMultipleNotShortCircuitMode()

--- a/tests/Dotenv/FileTest.php
+++ b/tests/Dotenv/FileTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Dotenv\File\Paths;
+use Dotenv\File\Reader;
+use PHPUnit\Framework\TestCase;
+
+class FileTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private $folder;
+
+    public function setUp()
+    {
+        $this->folder = dirname(__DIR__).'/fixtures/env';
+    }
+
+    public function testBasicRead()
+    {
+        $this->assertSame(
+            [
+                $this->folder.DIRECTORY_SEPARATOR.'.env' => "FOO=bar\nBAR=baz\nSPACED=\"with spaces\"\n\nNULL=\n",
+            ],
+            Reader::read(
+                Paths::filePaths([$this->folder], ['.env'])
+            )
+        );
+    }
+
+    public function testFileReadMultipleNotShortCircuitMode()
+    {
+        $this->assertSame(
+            [
+                $this->folder.DIRECTORY_SEPARATOR.'.env' => "FOO=bar\nBAR=baz\nSPACED=\"with spaces\"\n\nNULL=\n",
+            ],
+            Reader::read(
+                Paths::filePaths([$this->folder], ['.env', 'example.env'])
+            )
+        );
+    }
+
+    public function testFileReadMultipleWithShortCircuitMode()
+    {
+        $this->assertSame(
+            [
+                $this->folder.DIRECTORY_SEPARATOR.'.env' => "FOO=bar\nBAR=baz\nSPACED=\"with spaces\"\n\nNULL=\n",
+                $this->folder.DIRECTORY_SEPARATOR.'example.env' => "EG=\"example\"\n",
+            ],
+            Reader::read(
+                Paths::filePaths([$this->folder], ['.env', 'example.env']),
+                false
+            )
+        );
+    }
+}

--- a/tests/fixtures/.env
+++ b/tests/fixtures/.env
@@ -1,6 +1,0 @@
-FOO=bar
-BAR=baz
-SPACED=with spaces
-
-NULL=
-  

--- a/tests/fixtures/env/example.env
+++ b/tests/fixtures/env/example.env
@@ -1,0 +1,1 @@
+EG="example"


### PR DESCRIPTION
It is now possible to specify multiple file names, as well as multiple directories to search. By default, we'll stop looking for files as soon as we find one, like we did when there were multiple directories. To disable this behaviour, and load all files in order, one can disable "short circuit" file loading with a new parameter.

For example:

```php
// load both .env and .env2 if found
// if only one file exists, load it
// if no files exist, crash
$dotenv = \Dotenv\Dotenv::create(__DIR__, ['.env', '.env2'], false);
$dotenv->load();
```

---

Closes #393.