### PR TITLE
[4.1] Implement variable name whitelist

### DIFF
--- a/tests/Dotenv/LoaderTest.php
+++ b/tests/Dotenv/LoaderTest.php
@@ -20,6 +20,18 @@ class LoaderTest extends TestCase
         $this->assertSame($expected, $loader->load($repository, $content));
     }
 
+    public function testLoaderWithWhitelist()
+    {
+        $adapter = new ArrayAdapter();
+        $repository = RepositoryBuilder::create()->withReaders([$adapter])->withWriters([$adapter])->make();
+        $loader = new Loader(['FOO']);
+
+        $this->assertSame(['FOO' => 'Hello'], $loader->load($repository, "FOO=\"Hello\"\nBAR=\"World!\"\n"));
+        $this->assertTrue($adapter->get('FOO')->isDefined());
+        $this->assertSame('Hello', $adapter->get('FOO')->get());
+        $this->assertFalse($adapter->get('BAR')->isDefined());
+    }
+
     public function providesAdapters()
     {
         return [


### PR DESCRIPTION
It is now possible to tell the loader to only allow a predefined set of variables to be loaded. Since whitelisting is a kinda edge case requirement, I'll not be adding special `create` methods, like I did for choosing between mutable and immutable. Directly newing up `Dotenv` will be required. This is to keep the interface nice and simple for the majority of users.

A full example is below, assuming the directory where the `.env` file is stored in `$directory` and the array of allowed environment variable names (case sensitive) is in `$whitelist`:

```php
<php

use Dotenv\Dotenv;
use Dotenv\Loader\Loader;
use Dotenv\Repository\RepositoryBuilder;
use Dotenv\Store\StoreBuilder;

$loader = new Loader($whitelist);
$repository = RepositoryBuilder::create()->immutable()->make();
$store = StoreBuilder::create()->withPaths($directory)->make();

$dotenv = new Dotenv($loader, $repository, $store);

$dotenv->load();
```

---

// cc @ilimic1
