### PR TITLE
Keep README file when exporting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,5 @@
 /phpstan.neon.dist export-ignore
 /phpstan.tests.neon.dist export-ignore
 /phpunit.xml.dist export-ignore
-/README.md export-ignore
 /UPGRADING.md export-ignore
 /vendor-bin export-ignore


### PR DESCRIPTION
I think keeping the README file when exporting (ie: installing the project as deps) is valuable.
People will be able to read it from their vendors in case they need information from the project (or when they are working offline for example).