### PR TITLE
Adding safeLoad() information on README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->safeLoad();
 ```
 
-Alternatively, you can pass in a filename as the second parameter if you would
+Optionally you can pass in a filename as the second parameter if you would
 like to use something other than `.env`:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -98,13 +98,22 @@ $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
 ```
 
-Optionally you can pass in a filename as the second parameter, if you would
+If you don't want any exceptions to be thrown if no `.env` file is found (useful when you want it to be optional), use `safeLoad()`:
+
+```php
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+$dotenv->safeLoad();
+```
+
+Alternatively, you can pass in a filename as the second parameter if you would
 like to use something other than `.env`:
 
 ```php
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__, 'myconfig');
 $dotenv->load();
 ```
+
+
 
 All of the defined variables are now available in the `$_ENV` and `$_SERVER`
 super-globals.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
 ```
 
-If you don't want any exceptions to be thrown if no `.env` file is found (useful when you want it to be optional), use `safeLoad()`:
+If you don't want any exceptions to be thrown if no `.env` file is found, use `safeLoad()`:
 
 ```php
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
@@ -112,8 +112,6 @@ like to use something other than `.env`:
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__, 'myconfig');
 $dotenv->load();
 ```
-
-
 
 All of the defined variables are now available in the `$_ENV` and `$_SERVER`
 super-globals.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
 ```
 
-If you don't want any exceptions to be thrown if no `.env` file is found, use `safeLoad()`:
+To suppress the exception that is thrown when there is no `.env` file, you can:
 
 ```php
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->safeLoad();
 ```
 
-Optionally you can pass in a filename as the second parameter if you would
+Optionally you can pass in a filename as the second parameter, if you would
 like to use something other than `.env`:
 
 ```php


### PR DESCRIPTION
As mentioned on #84, nowhere in the README.md file contains any information regarding the safeLoad() method which allows users to suppress exceptions when no `.env` file is found.