### PR TITLE
Update short circuit mode test names

### DIFF
--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -100,7 +100,7 @@ final class DotenvTest extends TestCase
         self::assertEmpty($_SERVER['NULL']);
     }
 
-    public function testDotenvLoadsEnvironmentVarsMultipleNotShortCircuitMode()
+    public function testDotenvLoadsEnvironmentVarsMultipleWithShortCircuitMode()
     {
         $dotenv = Dotenv::createMutable(self::$folder, ['.env', 'example.env']);
 
@@ -110,7 +110,7 @@ final class DotenvTest extends TestCase
         );
     }
 
-    public function testDotenvLoadsEnvironmentVarsMultipleWithShortCircuitMode()
+    public function testDotenvLoadsEnvironmentVarsMultipleWithoutShortCircuitMode()
     {
         $dotenv = Dotenv::createMutable(self::$folder, ['.env', 'example.env'], false);
 


### PR DESCRIPTION
The current test called `WithShortCircuitMode` passes `false` to disable the short-circuit, and the test called `NotShortCircuitMode` uses the default value which enables short-circuit (only loads the first found env file). This PR inverses the names of these tests, as that makes more sense in my mind.

Please let me know if I have misunderstood the meaning of these test names.