### PR TITLE
Void return

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -26,7 +26,7 @@ final class Parser implements ParserInterface
             return 'Could not split into separate lines.';
         })->flatMap(static function (array $lines) {
             return self::process(Lines::process($lines));
-        })->mapError(static function (string $error) {
+        })->mapError(static function (string $error): void {
             throw new InvalidFileException(\sprintf('Failed to parse dotenv file. %s', $error));
         })->success()->get();
     }

--- a/src/Store/File/Reader.php
+++ b/src/Store/File/Reader.php
@@ -73,7 +73,7 @@ final class Reader
         $content = Option::fromValue(@\file_get_contents($path), false);
 
         return $content->flatMap(static function (string $content) use ($encoding) {
-            return Str::utf8($content, $encoding)->mapError(static function (string $error) {
+            return Str::utf8($content, $encoding)->mapError(static function (string $error): void {
                 throw new InvalidEncodingException($error);
             })->success();
         });


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.