### PR TITLE
Array push

### DIFF
--- a/src/Parser/Lines.php
+++ b/src/Parser/Lines.php
@@ -64,7 +64,7 @@ final class Lines
         }
 
         if ($multiline) {
-            \array_push($buffer, $line);
+            $buffer[] = $line;
 
             if (self::looksLikeMultilineStop($line, $started)) {
                 $multiline = false;


### PR DESCRIPTION
Converts simple usages of array_push($x, $y); to $x[] = $y;.