### PR TITLE
Remove requirement of `symfony/polyfill-ctype`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": "^7.1.3 || ^8.0",
+        "ext-ctype": "*",
         "ext-pcre": "*",
         "graham-campbell/result-type": "^1.0.2",
         "phpoption/phpoption": "^1.8",
-        "symfony/polyfill-ctype": "^1.23",
         "symfony/polyfill-mbstring": "^1.23.1",
         "symfony/polyfill-php80": "^1.23.1"
     },


### PR DESCRIPTION
I may be wrong, but I guess that `symfony/polyfill-ctype` is most of the time useless due to presence of `ctype` extension on system on which it is installed. Indeed `ctype` PHP extension is enabled by default during PHP compilation, according to [documentation](https://www.php.net/manual/en/ctype.installation.php) and is provided by default during PHP installation by many distributions. For instance, it is provided by `php-common` package on OS that are using DEB (Debian, Ubuntu, ...) or RPM (RedHat, CentOS, Fedora, ...) packaging systems, and is also provided in the Windows versions of PHP.

Since `composer` v2, it is possible to indicates that an extension is provided by a PHP package, and `symfony` polyfills are using this feature (see https://github.com/symfony/polyfill/pull/374).

Instead of requiering `symfony/polyfill-ctype`, it could be possible to require `ext-ctype` directlty. People would still be able to require the polyfill by themselves, to be able to install `vlucas/phpdotenv` component on machine that does not have this extension. In this case, `composer check-platform-reqs` would handle it this way:
```
Checking platform requirements for packages in the vendor dir
ext-ctype            *          success provided by symfony/polyfill-ctype
ext-pcre             8.2.4      success
php                  8.2.4      success
```

Such a change is important. It may be done in a `v5.6.0` verson, but would probably require a focus on this in changelog.

Also, a comment could be added in `README.md` and `UPGRADING.md` files, to indicates possibility to use a polyfill.