### PR TITLE
Removes $ in front of the terminal command on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ dotenv](https://github.com/bkeepers/dotenv).
 Installation is super-easy via [Composer](https://getcomposer.org/):
 
 ```bash
-$ composer require vlucas/phpdotenv
+composer require vlucas/phpdotenv
 ```
 
 or add it by hand to your `composer.json` file.


### PR DESCRIPTION
This prevents copying the $ sign when the copy icon is clicked on GitHub