### PR TITLE
Update README.md: make composer require command copy-pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ dotenv](https://github.com/bkeepers/dotenv).
 Installation is super-easy via [Composer](https://getcomposer.org/):
 
 ```bash
-$ composer require vlucas/phpdotenv
+composer require vlucas/phpdotenv
 ```
 
 or add it by hand to your `composer.json` file.


### PR DESCRIPTION
to respect "copy" button that currently copies `$ composer require vlucas/phpdotenv` string
![image](https://github.com/vlucas/phpdotenv/assets/5278175/ac77f140-1f8f-40da-8753-73cbf64b6559)


