### PR TITLE
Pass explicit trim characters ahead of PHP 8.6

### DIFF
--- a/src/Parser/EntryParser.php
+++ b/src/Parser/EntryParser.php
@@ -70,7 +70,9 @@ final class EntryParser
     {
         /** @var array{string, string|null} */
         $result = Str::pos($line, '=')->map(static function () use ($line) {
-            return \array_map('trim', \explode('=', $line, 2));
+            return \array_map(static function (string $part) {
+                return \trim($part, " \n\r\t\0\x0B");
+            }, \explode('=', $line, 2));
         })->getOrElse([$line, null]);
 
         if ($result[0] === '') {
@@ -95,7 +97,7 @@ final class EntryParser
     private static function parseName(string $name)
     {
         if (Str::len($name) > 8 && Str::substr($name, 0, 6) === 'export' && \ctype_space(Str::substr($name, 6, 1))) {
-            $name = \ltrim(Str::substr($name, 6));
+            $name = \ltrim(Str::substr($name, 6), " \t\n\r\v\f");
         }
 
         if (self::isQuotedName($name)) {
@@ -156,7 +158,7 @@ final class EntryParser
      */
     private static function parseValue(string $value)
     {
-        if (\trim($value) === '') {
+        if (\trim($value, " \n\r\t\0\x0B") === '') {
             /** @var \GrahamCampbell\ResultType\Result<\Dotenv\Parser\Value, string> */
             return Success::create(Value::blank());
         }

--- a/src/Parser/Lines.php
+++ b/src/Parser/Lines.php
@@ -120,7 +120,7 @@ final class Lines
      */
     private static function isCommentOrWhitespace(string $line)
     {
-        $line = \trim($line);
+        $line = \trim($line, " \n\r\t\0\x0B");
 
         return $line === '' || (isset($line[0]) && $line[0] === '#');
     }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -67,7 +67,7 @@ class Validator
     {
         return $this->assertNullable(
             static function (string $value) {
-                return Str::len(\trim($value)) > 0;
+                return Str::len(\trim($value, " \n\r\t\0\x0B")) > 0;
             },
             'is empty'
         );


### PR DESCRIPTION
PHP 8.6 adds the form feed character to the default `$characters` set of `trim`, `ltrim`, and `rtrim`, so calls relying on the default would change behavior there. This passes an explicit character set at the five calls that relied on it: the `notEmpty` validation, comment and whitespace line detection, the name/value split (converted from a callable-string `array_map('trim', ...)` to a closure so it can carry the set), and blank-value detection all freeze the pre-8.6 set, keeping behavior identical on every PHP version.

The `ltrim` after the `export` prefix instead uses the full whitespace set, space, horizontal tab, line feed, carriage return, vertical tab, and form feed, matching the `ctype_space` guard on the preceding line. That guard already accepts form feed as the separator, but the pre-8.6 default never stripped it, so `export` followed by a form feed produced an invalid-name error; the two now agree on every PHP version. An audit of the rest of the package found nothing else: all other regex work goes through the `Util\Regex` result wrapper with PCRE error reporting, and every pattern is anchored with `\A`/`\z` or the `A` modifier.
