### PR TITLE
Fix parsing of export with a single-character variable name

### DIFF
--- a/src/Parser/EntryParser.php
+++ b/src/Parser/EntryParser.php
@@ -96,7 +96,7 @@ final class EntryParser
      */
     private static function parseName(string $name)
     {
-        if (Str::len($name) > 8 && Str::substr($name, 0, 6) === 'export' && \ctype_space(Str::substr($name, 6, 1))) {
+        if (Str::len($name) >= 8 && Str::substr($name, 0, 6) === 'export' && \ctype_space(Str::substr($name, 6, 1))) {
             $name = \ltrim(Str::substr($name, 6), " \t\n\r\v\f");
         }
 

--- a/tests/Dotenv/Parser/EntryParserTest.php
+++ b/tests/Dotenv/Parser/EntryParserTest.php
@@ -115,6 +115,18 @@ final class EntryParserTest extends TestCase
         $this->checkPositiveResult($result, 'FOO', 'bar baz');
     }
 
+    public function testExportParseSingleCharName()
+    {
+        $result = EntryParser::parse('export A=1');
+        $this->checkPositiveResult($result, 'A', '1');
+    }
+
+    public function testExportParseTabSingleCharName()
+    {
+        $result = EntryParser::parse("export\tA=1");
+        $this->checkPositiveResult($result, 'A', '1');
+    }
+
     public function testExportParseFail()
     {
         $result = EntryParser::parse('export "FOO="bar baz"');


### PR DESCRIPTION
A dotenv file containing an export line with a single-character variable name fails to parse:

```
export A=1
```

```
Dotenv\Exception\InvalidFileException: Failed to parse dotenv file.
Encountered an invalid name at [export A].
```

Since the exception is thrown at file level, one such line rejects the entire file. `export AB=1` and longer names work fine.

The cause is the guard in `EntryParser::parseName()`:

```php
if (Str::len($name) > 8 && Str::substr($name, 0, 6) === 'export' && \ctype_space(Str::substr($name, 6, 1))) {
```

`export A` is exactly 8 characters, so the strict `> 8` comparison skips the prefix stripping and the raw string `export A` is then rejected as an invalid name.

This PR relaxes the guard to `>= 8` and adds regression tests for both space and tab separators. The other conditions are unchanged, so inputs like `exportFOO=...` (no whitespace after the prefix) or a variable actually named `export` are unaffected.

Full test suite passes: 252 tests, 518 assertions.
