### PR TITLE
Fix parsing of export with single character variable names

### DIFF
--- a/src/Parser/EntryParser.php
+++ b/src/Parser/EntryParser.php
@@ -96,7 +96,7 @@ final class EntryParser
      */
     private static function parseName(string $name)
     {
-        if (Str::len($name) > 8 && Str::substr($name, 0, 6) === 'export' && \ctype_space(Str::substr($name, 6, 1))) {
+        if (Str::substr($name, 0, 6) === 'export' && \ctype_space(Str::substr($name, 6, 1))) {
             $name = \ltrim(Str::substr($name, 6), " \t\n\r\v\f");
         }
 

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -211,6 +211,7 @@ final class DotenvTest extends TestCase
         self::assertSame('with spaces', $_SERVER['ESPACED']);
         self::assertSame('123', $_SERVER['EDQUOTED']);
         self::assertSame('456', $_SERVER['ESQUOTED']);
+        self::assertSame('789', $_SERVER['E']);
         self::assertEmpty($_SERVER['ENULL']);
     }
 

--- a/tests/Dotenv/Parser/EntryParserTest.php
+++ b/tests/Dotenv/Parser/EntryParserTest.php
@@ -115,6 +115,18 @@ final class EntryParserTest extends TestCase
         $this->checkPositiveResult($result, 'FOO', 'bar baz');
     }
 
+    public function testExportParseSingleCharName()
+    {
+        $result = EntryParser::parse('export A=1');
+        $this->checkPositiveResult($result, 'A', '1');
+    }
+
+    public function testExportParseNoWhitespace()
+    {
+        $result = EntryParser::parse('exportFOO=bar');
+        $this->checkPositiveResult($result, 'exportFOO', 'bar');
+    }
+
     public function testExportParseFail()
     {
         $result = EntryParser::parse('export "FOO="bar baz"');

--- a/tests/fixtures/env/exported.env
+++ b/tests/fixtures/env/exported.env
@@ -3,5 +3,6 @@ export EBAR = "baz"
 export ESPACED="with spaces"
 export "EDQUOTED" = 123
 export 'ESQUOTED' = 456
+export E=789
 
 export    ENULL=""


### PR DESCRIPTION
A line such as `export A=1` was rejected with an invalid name error, and with it the whole file, because the guard that strips the leading export prefix required the name to be longer than eight characters, which excludes the single character case. The length check was redundant given the prefix and whitespace checks that follow it, so it is removed. This supersedes #598 and adds a regression test along with an end to end fixture line.