### PR TITLE
Fix memory-safety crash on invalid UTF-8 variable names

### DIFF
--- a/src/Parser/EntryParser.php
+++ b/src/Parser/EntryParser.php
@@ -143,7 +143,7 @@ final class EntryParser
             return true;
         }
 
-        return Regex::matches('~(*UTF8)\A[\p{Ll}\p{Lu}\p{M}\p{N}_.]+\z~', $name)->success()->getOrElse(false);
+        return Regex::matches('~\A[\p{Ll}\p{Lu}\p{M}\p{N}_.]+\z~u', $name)->success()->getOrElse(false);
     }
 
     /**

--- a/src/Parser/EntryParser.php
+++ b/src/Parser/EntryParser.php
@@ -96,12 +96,12 @@ final class EntryParser
      */
     private static function parseName(string $name)
     {
-        if (Str::substr($name, 0, 6) === 'export' && \ctype_space(Str::substr($name, 6, 1))) {
-            $name = \ltrim(Str::substr($name, 6), " \t\n\r\v\f");
+        if (\strlen($name) > 6 && \substr($name, 0, 6) === 'export' && \ctype_space($name[6])) {
+            $name = \ltrim(\substr($name, 6), " \t\n\r\v\f");
         }
 
         if (self::isQuotedName($name)) {
-            $name = Str::substr($name, 1, -1);
+            $name = \substr($name, 1, -1);
         }
 
         if (!self::isValidName($name)) {
@@ -120,12 +120,12 @@ final class EntryParser
      */
     private static function isQuotedName(string $name)
     {
-        if (Str::len($name) < 3) {
+        if (\strlen($name) < 3) {
             return false;
         }
 
-        $first = Str::substr($name, 0, 1);
-        $last = Str::substr($name, -1, 1);
+        $first = $name[0];
+        $last = $name[\strlen($name) - 1];
 
         return ($first === '"' && $last === '"') || ($first === '\'' && $last === '\'');
     }

--- a/tests/Dotenv/Parser/EntryParserTest.php
+++ b/tests/Dotenv/Parser/EntryParserTest.php
@@ -175,6 +175,24 @@ final class EntryParserTest extends TestCase
         $this->checkErrorResult($result, "Encountered an invalid name at [\xFF\xFE].");
     }
 
+    public function testParseNameWithSubstituteCharacterConfigured()
+    {
+        if (\PHP_VERSION_ID < 80302 || !\extension_loaded('mbstring')) {
+            self::markTestSkipped('Requires the native mbstring substitution behaviour of PHP 8.3.2.');
+        }
+
+        $previous = \mb_substitute_character();
+        \mb_substitute_character(0x41);
+
+        $quoted = EntryParser::parse("\"\xC3\"=evil");
+        $exported = EntryParser::parse("export \xC3=evil");
+
+        \mb_substitute_character($previous);
+
+        $this->checkErrorResult($quoted, "Encountered an invalid name at [\xC3].");
+        $this->checkErrorResult($exported, "Encountered an invalid name at [\xC3].");
+    }
+
     public function testParserEscapingDouble()
     {
         $result = EntryParser::parse('FOO_BAD="iiiiviiiixiiiiviiii\\a"');

--- a/tests/Dotenv/Parser/EntryParserTest.php
+++ b/tests/Dotenv/Parser/EntryParserTest.php
@@ -157,6 +157,24 @@ final class EntryParserTest extends TestCase
         $this->checkErrorResult($result, 'Encountered an invalid name at [FOO_ASD!].');
     }
 
+    public function testParseInvalidUtf8Name()
+    {
+        $result = EntryParser::parse("\xC3=1");
+        $this->checkErrorResult($result, "Encountered an invalid name at [\xC3].");
+    }
+
+    public function testParseTruncatedUtf8Name()
+    {
+        $result = EntryParser::parse("A\xE2\x82=1");
+        $this->checkErrorResult($result, "Encountered an invalid name at [A\xE2\x82].");
+    }
+
+    public function testParseUtf16ByteOrderMarkName()
+    {
+        $result = EntryParser::parse("\xFF\xFE=1");
+        $this->checkErrorResult($result, "Encountered an invalid name at [\xFF\xFE].");
+    }
+
     public function testParserEscapingDouble()
     {
         $result = EntryParser::parse('FOO_BAD="iiiiviiiixiiiiviiii\\a"');

--- a/tests/Dotenv/Parser/ParserTest.php
+++ b/tests/Dotenv/Parser/ParserTest.php
@@ -63,6 +63,14 @@ final class ParserTest extends TestCase
         (new Parser())->parse('FOO_ASD!=BAZ');
     }
 
+    public function testParseInvalidUtf8Name()
+    {
+        $this->expectException(InvalidFileException::class);
+        $this->expectExceptionMessage("Failed to parse dotenv file. Encountered an invalid name at [\xC3].");
+
+        (new Parser())->parse("\xC3=1");
+    }
+
     /**
      * @param \Dotenv\Parser\Entry $entry
      * @param string               $name


### PR DESCRIPTION
Variable-name validation enabled PCRE UTF-8 mode with the in-pattern (*UTF8) verb rather than the u modifier, so PHP never checked that the subject was valid UTF-8 before matching. On a malformed byte sequence reaching Dotenv::parse or Parser::parse, where string input is not passed through the file reader's UTF-8 normalisation, the matcher reads past the end of the subject buffer, producing nondeterministic accept and reject results and a reproducible segmentation fault. Switching to the u modifier makes PHP validate the subject and reject invalid UTF-8 deterministically, which is exactly what name validation intends, and leaves every valid ASCII and UTF-8 name untouched. The name grammar itself, the export prefix strip, the quote delimiter checks and their length guard, is now handled with byte operations too, because running it through mbstring meant that on PHP 8.3.2 and later with a non-default substitute character configured, the replacement of malformed bytes could synthesise a valid-looking name, quote pair or export prefix and let an invalid name slip past validation, in the worst case colliding with a legitimate key defined earlier in the file. This is intended to land before v5.7.0 is tagged.
