### PR TITLE
Remove quadratic value parsing

### DIFF
--- a/src/Parser/EntryParser.php
+++ b/src/Parser/EntryParser.php
@@ -170,25 +170,36 @@ final class EntryParser
             return Success::create(Value::blank()->append($literal->get(), false));
         }
 
-        $result = Success::create([Value::blank(), self::INITIAL_STATE]);
+        $chars = '';
+        $pending = '';
+        $length = 0;
+        $vars = [];
+        $state = self::INITIAL_STATE;
 
         foreach (Lexer::lex($value) as $token) {
-            $result = $result->flatMap(static function (array $data) use ($token) {
-                return self::processToken($data[1], $token)->map(static function (array $val) use ($data) {
-                    return [$data[0]->append($val[0], $val[1]), $val[2]];
-                });
-            });
-        }
+            $result = self::processToken($state, $token);
 
-        return $result->flatMap(static function (array $result) {
-            if (in_array($result[1], self::REJECT_STATES, true)) {
-                return Error::create('a missing closing quote');
+            if ($result->error()->isDefined()) {
+                return Error::create(self::getErrorMessage($result->error()->get(), $value));
             }
 
-            return Success::create($result[0]);
-        })->mapError(static function (string $err) use ($value) {
-            return self::getErrorMessage($err, $value);
-        });
+            [$chunk, $var, $state] = $result->success()->get();
+
+            if ($var) {
+                $chars .= $pending;
+                $length += Str::len($pending);
+                $pending = '';
+                $vars[] = $length;
+            }
+
+            $pending .= $chunk;
+        }
+
+        if (\in_array($state, self::REJECT_STATES, true)) {
+            return Error::create(self::getErrorMessage('a missing closing quote', $value));
+        }
+
+        return Success::create(Value::create($chars.$pending, $vars));
     }
 
     /**

--- a/src/Parser/Value.php
+++ b/src/Parser/Value.php
@@ -47,6 +47,19 @@ final class Value
     }
 
     /**
+     * Create a new value instance.
+     *
+     * @param string $chars
+     * @param int[]  $vars
+     *
+     * @return \Dotenv\Parser\Value
+     */
+    public static function create(string $chars, array $vars)
+    {
+        return new self($chars, $vars);
+    }
+
+    /**
      * Create a new value instance, appending the characters.
      *
      * @param string $chars

--- a/tests/Dotenv/Parser/EntryParserTest.php
+++ b/tests/Dotenv/Parser/EntryParserTest.php
@@ -90,6 +90,13 @@ final class EntryParserTest extends TestCase
         $this->checkPositiveResult($result, 'FOO', 'TEST $BAR $$BAZ', [11, 10, 5]);
     }
 
+    public function testInlineVariableOffsetAtChunkBoundary()
+    {
+        $prefix = \str_repeat('a', 999).'€';
+        $result = EntryParser::parse('FOO="'.$prefix.'$BAR"');
+        $this->checkPositiveResult($result, 'FOO', $prefix.'$BAR', [1000]);
+    }
+
     public function testNonInlineVariable()
     {
         $result = EntryParser::parse('FOO=\'TEST $BAR $$BAZ\'');


### PR DESCRIPTION
The value parser rebuilt an immutable value object once per lexer token, copying the whole accumulated string and recomputing its length each time, which is quadratic in the length of a value composed of many small tokens, so a single call to the public parse method on an adversarial value takes seconds. This accumulates the characters and variable offsets directly and builds the value once, removing the repeated immutable value and prefix reconstruction and substantially reducing allocations and copying. Parsing a single entry whose 16MB double-quoted value contains an escaped dollar, which forces the chunked lexer path, drops from 12.4s to 75ms on PHP 8.4, and an unquoted value of 80,000 inline variable markers drops from 9.2s to 101ms, with measured scaling exponents of about 1.0 against 1.9 before; the same shapes measure linear on PHP 7.2, 7.4, 8.2 and 8.3, and output is byte-identical over a 211,158-input differential corpus. This is stacked on #603.
