### PR TITLE
Resolve nested variables with fewer copies

### DIFF
--- a/src/Loader/Resolver.php
+++ b/src/Loader/Resolver.php
@@ -37,9 +37,23 @@ final class Resolver
      */
     public static function resolve(RepositoryInterface $repository, Value $value)
     {
-        return \array_reduce($value->getVars(), static function (string $s, int $i) use ($repository) {
-            return Str::substr($s, 0, $i).self::resolveVariable($repository, Str::substr($s, $i));
-        }, $value->getChars());
+        $chars = $value->getChars();
+        $vars = $value->getVars();
+
+        if ($vars === []) {
+            return $chars;
+        }
+
+        $tail = '';
+        $cut = Str::len($chars);
+
+        foreach ($vars as $i) {
+            $segment = Str::substr($chars, $i, $cut - $i);
+            $tail = self::resolveVariable($repository, $segment.$tail);
+            $cut = $i;
+        }
+
+        return Str::substr($chars, 0, $cut).$tail;
     }
 
     /**

--- a/tests/Dotenv/Loader/LoaderTest.php
+++ b/tests/Dotenv/Loader/LoaderTest.php
@@ -56,6 +56,18 @@ final class LoaderTest extends TestCase
         $loader->load($repository, (new Parser())->parse('FOO="""'));
     }
 
+    public function testLoaderPreservesInvalidUtf8BytesFromRepositoryValues()
+    {
+        $adapter = ArrayAdapter::create()->get();
+        $repository = RepositoryBuilder::createWithNoAdapters()->addReader($adapter)->addWriter($adapter)->make();
+        $loader = new Loader();
+
+        $content = "LEFT=left\nBAD=\xC3\nRESULT=\"\${LEFT}\${BAD}\"";
+        $expected = ['LEFT' => 'left', 'BAD' => "\xC3", 'RESULT' => "left\xC3"];
+
+        self::assertSame($expected, $loader->load($repository, (new Parser())->parse($content)));
+    }
+
     /**
      * @return array<int,\Dotenv\Repository\Adapter\AdapterInterface|string>[]
      */


### PR DESCRIPTION
Nested-variable resolution folded across the variable offsets and re-sliced the entire value, prefix included, for every reference, which is costly for a value with many references. This preserves the exact right-to-left resolution order, including the cascade where a resolved inner reference forms an outer one, and rebuilds only the unresolved tail at each step, with markedly fewer string copies. Output is byte-identical whenever the parsed characters and every repository value incorporated during resolution are valid UTF-8, and on PHP 8.2 and earlier it is byte-identical on all input. For malformed bytes on later runtimes the old code re-sliced already-resolved text through mb_substr, which since PHP 8.3 replaces invalid bytes with the configured mbstring substitution character, so a value with several references could return already-substituted text; the new code preserves those bytes in the resolved tail on every runtime, which is what PHP 8.2 and earlier already produced. Resolving a value of 4,000 nested references to 64-byte substitutions drops from 849ms to 67ms on PHP 8.4 and from 2.1s to 135ms on PHP 7.2, with smaller gains on PHP 7.4 and 8.2, and resolution remains quadratic in the number of references, so this is a constant-factor improvement that could still be dropped without affecting the rest of the series. This is stacked on #604.
