### PR TITLE
Strip a leading BOM from string input

### DIFF
--- a/src/Store/StringStore.php
+++ b/src/Store/StringStore.php
@@ -32,6 +32,10 @@ final class StringStore implements StoreInterface
      */
     public function read()
     {
+        if (\substr($this->content, 0, 3) === "\xEF\xBB\xBF") {
+            return \substr($this->content, 3);
+        }
+
         return $this->content;
     }
 }

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -404,6 +404,13 @@ final class DotenvTest extends TestCase
         self::assertSame($output, [7 => '1', 'FOO' => 'b', 123 => 'x']);
     }
 
+    public function testDotenvParseStripsUtf8ByteOrderMark()
+    {
+        self::assertSame(['KEY' => '1'], Dotenv::parse("\xEF\xBB\xBFKEY=1"));
+        self::assertSame(['A' => '2'], Dotenv::parse("\xEF\xBB\xBF# c\nA=2"));
+        self::assertSame(['B' => '3'], Dotenv::parse("\xEF\xBB\xBF\nB=3"));
+    }
+
     public function testDotenvParseEmptyCase()
     {
         $output = Dotenv::parse('');


### PR DESCRIPTION
Byte order marks are stripped when reading .env files but not when content is passed to the string parser, so the same bytes that load cleanly from a file throw an invalid-name error when handed to Dotenv::parse. Editors on Windows routinely prepend a UTF-8 byte order mark, and users increasingly fetch file contents themselves and parse the string. Stripping a leading UTF-8 byte order mark from string content makes the two entry points behave the same. This is stacked on #605.