### PR TITLE
Improve diagnostics and messages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,3 +68,32 @@ jobs:
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit
+
+  polyfill:
+    name: PHP 8.4 Polyfill Parity
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          coverage: none
+          ini-values: disable_functions=mb_strcut,mb_strimwidth,mb_convert_kana,mb_split,mb_parse_str,mb_send_mail,mb_regex_encoding,mb_regex_set_options,mb_preferred_mime_name
+
+      - name: Setup Problem Matchers
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install Latest Dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --no-interaction --no-progress
+
+      - name: Execute PHPUnit
+        run: vendor/bin/phpunit

--- a/src/Parser/EntryParser.php
+++ b/src/Parser/EntryParser.php
@@ -319,6 +319,8 @@ final class EntryParser
             $line = self::cutBytes($line, 80).'...';
         }
 
+        $line = \addcslashes($line, "\0..\37\177");
+
         return \sprintf(
             'Encountered %s at [%s].',
             $cause,

--- a/src/Parser/EntryParser.php
+++ b/src/Parser/EntryParser.php
@@ -309,10 +309,53 @@ final class EntryParser
      */
     private static function getErrorMessage(string $cause, string $subject)
     {
+        $line = \strtok($subject, "\n");
+
+        if ($line === false) {
+            $line = '';
+        }
+
+        if (\strlen($line) > 80) {
+            $line = self::cutBytes($line, 80).'...';
+        }
+
         return \sprintf(
             'Encountered %s at [%s].',
             $cause,
-            \strtok($subject, "\n")
+            $line
         );
+    }
+
+    /**
+     * Cut the string to at most the given number of bytes.
+     *
+     * The cut never splits a multibyte UTF-8 character: an incomplete
+     * trailing sequence is dropped entirely.
+     *
+     * @param string $input
+     * @param int    $limit
+     *
+     * @return string
+     */
+    private static function cutBytes(string $input, int $limit)
+    {
+        $prefix = \substr($input, 0, $limit);
+        $length = \strlen($prefix);
+
+        for ($i = $length - 1; $i >= 0 && $i >= $length - 4; $i--) {
+            $byte = \ord($prefix[$i]);
+
+            if (($byte & 0xC0) !== 0x80) {
+                $need = $byte < 0x80 ? 1 : ($byte >= 0xF0 ? 4 : ($byte >= 0xE0 ? 3 : ($byte >= 0xC0 ? 2 : 1)));
+
+                if ($i + $need > $length) {
+                    $prefix = \substr($prefix, 0, $i);
+                }
+
+                break;
+            }
+        }
+
+        return $prefix;
     }
 }

--- a/src/Repository/RepositoryBuilder.php
+++ b/src/Repository/RepositoryBuilder.php
@@ -211,7 +211,7 @@ final class RepositoryBuilder
             throw new InvalidArgumentException(
                 \sprintf(
                     'Expected either an instance of %s or a class-string implementing %s',
-                    WriterInterface::class,
+                    AdapterInterface::class,
                     AdapterInterface::class
                 )
             );
@@ -228,7 +228,7 @@ final class RepositoryBuilder
     }
 
     /**
-     * Creates a repository builder with mutability enabled.
+     * Creates a repository builder with immutability enabled.
      *
      * @return \Dotenv\Repository\RepositoryBuilder
      */

--- a/src/Store/FileStore.php
+++ b/src/Store/FileStore.php
@@ -56,7 +56,7 @@ final class FileStore implements StoreInterface
     public function read()
     {
         if ($this->filePaths === []) {
-            throw new InvalidPathException('At least one environment file path must be provided.');
+            throw new InvalidPathException('At least one environment file path and file name must be provided.');
         }
 
         $contents = Reader::read($this->filePaths, $this->shortCircuit, $this->fileEncoding);

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -35,7 +35,7 @@ final class Str
      */
     public static function utf8(string $input, ?string $encoding = null)
     {
-        if ($encoding !== null && !\in_array($encoding, \mb_list_encodings(), true)) {
+        if ($encoding !== null && !self::isValidEncoding($encoding)) {
             return Error::create(
                 \sprintf('Illegal character encoding [%s] specified.', $encoding)
             );
@@ -61,6 +61,30 @@ final class Str
         }
 
         return Success::create($converted);
+    }
+
+    /**
+     * Is the given character encoding valid?
+     *
+     * @param string $encoding
+     *
+     * @return bool
+     */
+    private static function isValidEncoding(string $encoding)
+    {
+        foreach (\mb_list_encodings() as $candidate) {
+            if (\strcasecmp($candidate, $encoding) === 0) {
+                return true;
+            }
+
+            foreach (@\mb_encoding_aliases($candidate) as $alias) {
+                if (\strcasecmp($alias, $encoding) === 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -141,6 +141,15 @@ class Validator
      */
     public function allowedRegexValues(string $regex)
     {
+        if (@\preg_match($regex, '') === false && \preg_last_error() === \PREG_INTERNAL_ERROR) {
+            return $this->assertNullable(
+                static function (string $value) {
+                    return false;
+                },
+                \sprintf('could not be validated against the invalid regular expression "%s"', $regex)
+            );
+        }
+
         return $this->assertNullable(
             static function (string $value) use ($regex) {
                 return Regex::matches($regex, $value)->success()->getOrElse(false);

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -56,7 +56,7 @@ final class DotenvTest extends TestCase
         $dotenv = Dotenv::createMutable([]);
 
         $this->expectException(InvalidPathException::class);
-        $this->expectExceptionMessage('At least one environment file path must be provided.');
+        $this->expectExceptionMessage('At least one environment file path and file name must be provided.');
 
         $dotenv->load();
     }

--- a/tests/Dotenv/Parser/EntryParserTest.php
+++ b/tests/Dotenv/Parser/EntryParserTest.php
@@ -248,6 +248,12 @@ final class EntryParserTest extends TestCase
         $this->checkErrorResult($result, 'Encountered an unexpected escape sequence at ["'.\str_repeat('a', 77).'...].');
     }
 
+    public function testParserErrorMessageEscapesControlBytes()
+    {
+        $result = EntryParser::parse("FOO=\"a\x01b\q\"");
+        $this->checkErrorResult($result, 'Encountered an unexpected escape sequence at ["a\001b\q"].');
+    }
+
     /**
      * @param \GrahamCampbell\ResultType\Result<\Dotenv\Parser\Entry,string> $result
      * @param string                                                         $name

--- a/tests/Dotenv/Parser/EntryParserTest.php
+++ b/tests/Dotenv/Parser/EntryParserTest.php
@@ -236,6 +236,18 @@ final class EntryParserTest extends TestCase
         $this->checkErrorResult($result, 'Encountered a missing closing quote at ["\\].');
     }
 
+    public function testParserErrorMessageIsCapped()
+    {
+        $result = EntryParser::parse('FOO="'.\str_repeat('a', 100).'\q"');
+        $this->checkErrorResult($result, 'Encountered an unexpected escape sequence at ["'.\str_repeat('a', 79).'...].');
+    }
+
+    public function testParserErrorMessageCapDoesNotSplitCharacters()
+    {
+        $result = EntryParser::parse('FOO="'.\str_repeat('a', 77).'🚀'.\str_repeat('b', 20).'\q"');
+        $this->checkErrorResult($result, 'Encountered an unexpected escape sequence at ["'.\str_repeat('a', 77).'...].');
+    }
+
     /**
      * @param \GrahamCampbell\ResultType\Result<\Dotenv\Parser\Entry,string> $result
      * @param string                                                         $name

--- a/tests/Dotenv/Store/StoreTest.php
+++ b/tests/Dotenv/Store/StoreTest.php
@@ -76,6 +76,32 @@ final class StoreTest extends TestCase
         $builder->make()->read();
     }
 
+    public function testBasicReadLowercaseEncoding()
+    {
+        $builder = StoreBuilder::createWithNoNames()
+            ->addPath(self::$folder)
+            ->addName('windows.env')
+            ->fileEncoding('windows-1252');
+
+        self::assertSame(
+            "MBW=\"ñá\"\n",
+            $builder->make()->read()
+        );
+    }
+
+    public function testBasicReadAliasEncoding()
+    {
+        $builder = StoreBuilder::createWithNoNames()
+            ->addPath(self::$folder)
+            ->addName('utf8-with-bom-encoding.env')
+            ->fileEncoding('utf8');
+
+        self::assertSame(
+            "FOO=bar\nBAR=baz\nSPACED=\"with spaces\"\n",
+            $builder->make()->read()
+        );
+    }
+
     public function testFileReadMultipleShortCircuitModeDirect()
     {
         self::assertSame(

--- a/tests/Dotenv/ValidatorTest.php
+++ b/tests/Dotenv/ValidatorTest.php
@@ -462,7 +462,7 @@ final class ValidatorTest extends TestCase
         $dotenv->load();
 
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('One or more environment variables failed assertions: FOO does not match "/([[:lower:]{1{".');
+        $this->expectExceptionMessage('One or more environment variables failed assertions: FOO could not be validated against the invalid regular expression "/([[:lower:]{1{".');
 
         $dotenv->required('FOO')->allowedRegexValues('/([[:lower:]{1{');
     }


### PR DESCRIPTION
Parse error messages embedded the entire first line of a value, so a single malformed escape could copy a neighbouring secret verbatim into logs; the context is now capped at eighty bytes without splitting a UTF-8 character, using plain byte operations so the formatter cannot call an mbstring function the polyfill does not provide, and control bytes in the reported context are escaped so log lines stay printable. A malformed pattern passed to allowedRegexValues reported every value as a mismatch instead of the compile failure, the empty-file-path message blamed the path when the names list was empty, and the repository builder's error text and doc comments were inaccurate; these are corrected. Encoding names are now matched case-insensitively and through their aliases. A new tests workflow job runs the suite with the mbstring functions the polyfill does not implement disabled, so any future use of one fails in CI rather than only on installs that rely on the polyfill. This is stacked on #606.
