### PR TITLE
Require the covariant option and result types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-pcre": "*",
-        "graham-campbell/result-type": "^1.1.5",
-        "phpoption/phpoption": "^1.9.6",
+        "graham-campbell/result-type": "^1.2",
+        "phpoption/phpoption": "^1.10",
         "symfony/polyfill-ctype": "^1.26",
         "symfony/polyfill-mbstring": "^1.26",
         "symfony/polyfill-php80": "^1.26"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^PHPDoc tag @var with type GrahamCampbell\\ResultType\\Result\<Dotenv\\Parser\\Value\|null, string\> is not subtype of type GrahamCampbell\\ResultType\\Result\<Dotenv\\Parser\\Value, string\>\|GrahamCampbell\\ResultType\\Result\<null, mixed\>\.$#'
-			identifier: varTag.type
-			count: 1
-			path: src/Parser/EntryParser.php
-
-		-
 			message: '#^Only booleans are allowed in a negated boolean, int\|false given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 1
@@ -61,19 +55,19 @@ parameters:
 			path: src/Repository/Adapter/ServerConstAdapter.php
 
 		-
-			message: '#^Parameter \#1 \$callable of method PhpOption\\Some\<Dotenv\\Repository\\Adapter\\AdapterInterface\|string\>\:\:flatMap\(\) expects callable\(Dotenv\\Repository\\Adapter\\AdapterInterface\|string\)\: PhpOption\\Option\<S\>, static\-Closure\(mixed\)\: mixed given\.$#'
+			message: '#^Parameter \#1 \$callable of method PhpOption\\Some\<Dotenv\\Repository\\Adapter\\AdapterInterface\|string\>\:\:flatMap\(\) expects callable\(Dotenv\\Repository\\Adapter\\AdapterInterface\|string\)\: PhpOption\\Option\<S\>, Closure\(mixed\)\: mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Repository/RepositoryBuilder.php
 
 		-
-			message: '#^Parameter \#1 \$callable of method PhpOption\\Some\<Dotenv\\Repository\\Adapter\\ReaderInterface\|string\>\:\:flatMap\(\) expects callable\(Dotenv\\Repository\\Adapter\\ReaderInterface\|string\)\: PhpOption\\Option\<S\>, static\-Closure\(mixed\)\: mixed given\.$#'
+			message: '#^Parameter \#1 \$callable of method PhpOption\\Some\<Dotenv\\Repository\\Adapter\\ReaderInterface\|string\>\:\:flatMap\(\) expects callable\(Dotenv\\Repository\\Adapter\\ReaderInterface\|string\)\: PhpOption\\Option\<S\>, Closure\(mixed\)\: mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Repository/RepositoryBuilder.php
 
 		-
-			message: '#^Parameter \#1 \$callable of method PhpOption\\Some\<Dotenv\\Repository\\Adapter\\WriterInterface\|string\>\:\:flatMap\(\) expects callable\(Dotenv\\Repository\\Adapter\\WriterInterface\|string\)\: PhpOption\\Option\<S\>, static\-Closure\(mixed\)\: mixed given\.$#'
+			message: '#^Parameter \#1 \$callable of method PhpOption\\Some\<Dotenv\\Repository\\Adapter\\WriterInterface\|string\>\:\:flatMap\(\) expects callable\(Dotenv\\Repository\\Adapter\\WriterInterface\|string\)\: PhpOption\\Option\<S\>, Closure\(mixed\)\: mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Repository/RepositoryBuilder.php
@@ -91,21 +85,9 @@ parameters:
 			path: src/Repository/RepositoryBuilder.php
 
 		-
-			message: '#^Method Dotenv\\Util\\Regex\:\:occurrences\(\) should return GrahamCampbell\\ResultType\\Result\<int, string\> but returns GrahamCampbell\\ResultType\\Result\<int\<0, max\>, string\>\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Util/Regex.php
-
-		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
 			count: 1
-			path: src/Util/Str.php
-
-		-
-			message: '#^PHPDoc tag @var with type GrahamCampbell\\ResultType\\Result\<string, string\> is not subtype of type GrahamCampbell\\ResultType\\Result\<mixed, non\-falsy\-string\>\.$#'
-			identifier: varTag.type
-			count: 2
 			path: src/Util/Str.php
 
 		-

--- a/src/Parser/EntryParser.php
+++ b/src/Parser/EntryParser.php
@@ -51,7 +51,6 @@ final class EntryParser
             [$name, $value] = $parts;
 
             return self::parseName($name)->flatMap(static function (string $name) use ($value) {
-                /** @var Result<Value|null, string> */
                 $parsedValue = $value === null ? Success::create(null) : self::parseValue($value);
 
                 return $parsedValue->map(static function (?Value $value) use ($name) {
@@ -79,11 +78,9 @@ final class EntryParser
         }
 
         if ($result[0] === '') {
-            /** @var \GrahamCampbell\ResultType\Result<array{string, string|null},string> */
             return Error::create(self::getErrorMessage('an unexpected equals', $line));
         }
 
-        /** @var \GrahamCampbell\ResultType\Result<array{string, string|null},string> */
         return Success::create($result);
     }
 
@@ -108,11 +105,9 @@ final class EntryParser
         }
 
         if (!self::isValidName($name)) {
-            /** @var \GrahamCampbell\ResultType\Result<string, string> */
             return Error::create(self::getErrorMessage('an invalid name', $name));
         }
 
-        /** @var \GrahamCampbell\ResultType\Result<string, string> */
         return Success::create($name);
     }
 
@@ -166,14 +161,12 @@ final class EntryParser
     private static function parseValue(string $value)
     {
         if (\trim($value, " \n\r\t\0\x0B") === '') {
-            /** @var \GrahamCampbell\ResultType\Result<\Dotenv\Parser\Value, string> */
             return Success::create(Value::blank());
         }
 
         $literal = self::parseLiteral($value);
 
         if ($literal->isDefined()) {
-            /** @var \GrahamCampbell\ResultType\Result<\Dotenv\Parser\Value, string> */
             return Success::create(Value::blank()->append($literal->get(), false));
         }
 
@@ -189,11 +182,9 @@ final class EntryParser
 
         return $result->flatMap(static function (array $result) {
             if (in_array($result[1], self::REJECT_STATES, true)) {
-                /** @var \GrahamCampbell\ResultType\Result<\Dotenv\Parser\Value, string> */
                 return Error::create('a missing closing quote');
             }
 
-            /** @var \GrahamCampbell\ResultType\Result<\Dotenv\Parser\Value, string> */
             return Success::create($result[0]);
         })->mapError(static function (string $err) use ($value) {
             return self::getErrorMessage($err, $value);
@@ -233,87 +224,64 @@ final class EntryParser
         switch ($state) {
             case self::INITIAL_STATE:
                 if ($token === '\'') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::SINGLE_QUOTED_STATE]);
                 } elseif ($token === '"') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::DOUBLE_QUOTED_STATE]);
                 } elseif ($token === '#') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::COMMENT_STATE]);
                 } elseif ($token === '$') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create([$token, true, self::UNQUOTED_STATE]);
                 } else {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create([$token, false, self::UNQUOTED_STATE]);
                 }
             case self::UNQUOTED_STATE:
                 if ($token === '#') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::COMMENT_STATE]);
                 } elseif (\ctype_space($token)) {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::WHITESPACE_STATE]);
                 } elseif ($token === '$') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create([$token, true, self::UNQUOTED_STATE]);
                 } else {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create([$token, false, self::UNQUOTED_STATE]);
                 }
             case self::SINGLE_QUOTED_STATE:
                 if ($token === '\'') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::WHITESPACE_STATE]);
                 } else {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create([$token, false, self::SINGLE_QUOTED_STATE]);
                 }
             case self::DOUBLE_QUOTED_STATE:
                 if ($token === '"') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::WHITESPACE_STATE]);
                 } elseif ($token === '\\') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::ESCAPE_SEQUENCE_STATE]);
                 } elseif ($token === '$') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create([$token, true, self::DOUBLE_QUOTED_STATE]);
                 } else {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create([$token, false, self::DOUBLE_QUOTED_STATE]);
                 }
             case self::ESCAPE_SEQUENCE_STATE:
                 if ($token === '"' || $token === '\\') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create([$token, false, self::DOUBLE_QUOTED_STATE]);
                 } elseif ($token === '$') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create([$token, false, self::DOUBLE_QUOTED_STATE]);
                 } else {
                     $first = Str::substr($token, 0, 1);
                     if (\in_array($first, ['f', 'n', 'r', 't', 'v'], true)) {
-                        /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                         return Success::create([\stripcslashes('\\'.$first).Str::substr($token, 1), false, self::DOUBLE_QUOTED_STATE]);
                     } else {
-                        /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                         return Error::create('an unexpected escape sequence');
                     }
                 }
             case self::WHITESPACE_STATE:
                 if ($token === '#') {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::COMMENT_STATE]);
                 } elseif (!\ctype_space($token)) {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Error::create('unexpected whitespace');
                 } else {
-                    /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                     return Success::create(['', false, self::WHITESPACE_STATE]);
                 }
             case self::COMMENT_STATE:
-                /** @var \GrahamCampbell\ResultType\Result<array{string, bool, int}, string> */
                 return Success::create(['', false, self::COMMENT_STATE]);
             default:
                 throw new \Error('Parser entered invalid state.');

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -47,14 +47,12 @@ final class Parser implements ParserInterface
             $entry = EntryParser::parse($raw);
 
             if ($entry->error()->isDefined()) {
-                /** @var \GrahamCampbell\ResultType\Result<\Dotenv\Parser\Entry[], string> */
                 return Error::create($entry->error()->get());
             }
 
             $output[] = $entry->success()->get();
         }
 
-        /** @var \GrahamCampbell\ResultType\Result<\Dotenv\Parser\Entry[], string> */
         return Success::create($output);
     }
 }

--- a/src/Util/Regex.php
+++ b/src/Util/Regex.php
@@ -93,11 +93,9 @@ final class Regex
     private static function wrap($result)
     {
         if (\preg_last_error() !== \PREG_NO_ERROR) {
-            /** @var \GrahamCampbell\ResultType\Result<V,string> */
             return Error::create(\preg_last_error_msg());
         }
 
-        /** @var \GrahamCampbell\ResultType\Result<V,string> */
         return Success::create($result);
     }
 }

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -36,7 +36,6 @@ final class Str
     public static function utf8(string $input, ?string $encoding = null)
     {
         if ($encoding !== null && !\in_array($encoding, \mb_list_encodings(), true)) {
-            /** @var \GrahamCampbell\ResultType\Result<string, string> */
             return Error::create(
                 \sprintf('Illegal character encoding [%s] specified.', $encoding)
             );
@@ -47,7 +46,6 @@ final class Str
             @\mb_convert_encoding($input, 'UTF-8', $encoding);
 
         if (!is_string($converted)) {
-            /** @var \GrahamCampbell\ResultType\Result<string, string> */
             return Error::create(
                 \sprintf('Conversion from encoding [%s] failed.', $encoding ?? 'NULL')
             );
@@ -62,7 +60,6 @@ final class Str
             $converted = \substr($converted, 3);
         }
 
-        /** @var \GrahamCampbell\ResultType\Result<string, string> */
         return Success::create($converted);
     }
 


### PR DESCRIPTION
phpoption 1.10.0 and result-type 1.2.0 make Option and Result covariant in their type parameters, with precise return types on their factory and transformation methods. The parser and string utilities carried thirty-nine defensive inline @var casts purely to compensate for the old imprecise annotations, and under the covariant releases PHPStan reports those casts as invalid rather than merely redundant. This raises the minimum versions of the two dependencies, deletes the casts, and regenerates the PHPStan baseline, which shrinks from nineteen entries to sixteen. There are no runtime changes, as only version constraints and comments are touched.
