### PR TITLE
Improve option and result type precision

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,85 +13,19 @@ parameters:
 			path: src/Parser/Lexer.php
 
 		-
-			message: '#^PHPDoc tag @var with type PhpOption\\Option\<Dotenv\\Repository\\Adapter\\AdapterInterface\> is not subtype of type PhpOption\\Some\<Dotenv\\Repository\\Adapter\\ApacheAdapter\>\.$#'
-			identifier: varTag.type
-			count: 1
-			path: src/Repository/Adapter/ApacheAdapter.php
-
-		-
-			message: '#^PHPDoc tag @var with type PhpOption\\Option\<Dotenv\\Repository\\Adapter\\AdapterInterface\> is not subtype of type PhpOption\\Some\<Dotenv\\Repository\\Adapter\\ArrayAdapter\>\.$#'
-			identifier: varTag.type
-			count: 1
-			path: src/Repository/Adapter/ArrayAdapter.php
-
-		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
 			count: 1
 			path: src/Repository/Adapter/EnvConstAdapter.php
 
 		-
-			message: '#^PHPDoc tag @var with type PhpOption\\Option\<Dotenv\\Repository\\Adapter\\AdapterInterface\> is not subtype of type PhpOption\\Some\<Dotenv\\Repository\\Adapter\\EnvConstAdapter\>\.$#'
-			identifier: varTag.type
-			count: 1
-			path: src/Repository/Adapter/EnvConstAdapter.php
-
-		-
-			message: '#^PHPDoc tag @var with type PhpOption\\Option\<Dotenv\\Repository\\Adapter\\AdapterInterface\> is not subtype of type PhpOption\\Some\<Dotenv\\Repository\\Adapter\\PutenvAdapter\>\.$#'
-			identifier: varTag.type
-			count: 1
-			path: src/Repository/Adapter/PutenvAdapter.php
-
-		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
 			count: 1
 			path: src/Repository/Adapter/ServerConstAdapter.php
-
-		-
-			message: '#^PHPDoc tag @var with type PhpOption\\Option\<Dotenv\\Repository\\Adapter\\AdapterInterface\> is not subtype of type PhpOption\\Some\<Dotenv\\Repository\\Adapter\\ServerConstAdapter\>\.$#'
-			identifier: varTag.type
-			count: 1
-			path: src/Repository/Adapter/ServerConstAdapter.php
-
-		-
-			message: '#^Parameter \#1 \$callable of method PhpOption\\Some\<Dotenv\\Repository\\Adapter\\AdapterInterface\|string\>\:\:flatMap\(\) expects callable\(Dotenv\\Repository\\Adapter\\AdapterInterface\|string\)\: PhpOption\\Option\<S\>, Closure\(mixed\)\: mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Repository/RepositoryBuilder.php
-
-		-
-			message: '#^Parameter \#1 \$callable of method PhpOption\\Some\<Dotenv\\Repository\\Adapter\\ReaderInterface\|string\>\:\:flatMap\(\) expects callable\(Dotenv\\Repository\\Adapter\\ReaderInterface\|string\)\: PhpOption\\Option\<S\>, Closure\(mixed\)\: mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Repository/RepositoryBuilder.php
-
-		-
-			message: '#^Parameter \#1 \$callable of method PhpOption\\Some\<Dotenv\\Repository\\Adapter\\WriterInterface\|string\>\:\:flatMap\(\) expects callable\(Dotenv\\Repository\\Adapter\\WriterInterface\|string\)\: PhpOption\\Option\<S\>, Closure\(mixed\)\: mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Repository/RepositoryBuilder.php
-
-		-
-			message: '#^Parameter \#1 \$readers of class Dotenv\\Repository\\RepositoryBuilder constructor expects array\<Dotenv\\Repository\\Adapter\\ReaderInterface\>, array\<Dotenv\\Repository\\Adapter\\ReaderInterface\|S\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Repository/RepositoryBuilder.php
-
-		-
-			message: '#^Parameter \#2 \$writers of class Dotenv\\Repository\\RepositoryBuilder constructor expects array\<Dotenv\\Repository\\Adapter\\WriterInterface\>, array\<Dotenv\\Repository\\Adapter\\WriterInterface\|S\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Repository/RepositoryBuilder.php
 
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 1
-			path: src/Util/Str.php
-
-		-
-			message: '#^PHPDoc tag @var with type PhpOption\\Option\<int\> is not subtype of type PhpOption\\Option\<int\<0, max\>\|false\>\.$#'
-			identifier: varTag.type
 			count: 1
 			path: src/Util/Str.php

--- a/src/Repository/Adapter/ApacheAdapter.php
+++ b/src/Repository/Adapter/ApacheAdapter.php
@@ -23,12 +23,11 @@ final class ApacheAdapter implements AdapterInterface
     /**
      * Create a new instance of the adapter, if it is available.
      *
-     * @return \PhpOption\Option<\Dotenv\Repository\Adapter\AdapterInterface>
+     * @return \PhpOption\Option<self>
      */
     public static function create()
     {
         if (self::isSupported()) {
-            /** @var \PhpOption\Option<AdapterInterface> */
             return Some::create(new self());
         }
 

--- a/src/Repository/Adapter/ArrayAdapter.php
+++ b/src/Repository/Adapter/ArrayAdapter.php
@@ -29,11 +29,10 @@ final class ArrayAdapter implements AdapterInterface
     /**
      * Create a new instance of the adapter, if it is available.
      *
-     * @return \PhpOption\Option<\Dotenv\Repository\Adapter\AdapterInterface>
+     * @return \PhpOption\Option<self>
      */
     public static function create()
     {
-        /** @var \PhpOption\Option<AdapterInterface> */
         return Some::create(new self());
     }
 

--- a/src/Repository/Adapter/EnvConstAdapter.php
+++ b/src/Repository/Adapter/EnvConstAdapter.php
@@ -22,11 +22,10 @@ final class EnvConstAdapter implements AdapterInterface
     /**
      * Create a new instance of the adapter, if it is available.
      *
-     * @return \PhpOption\Option<\Dotenv\Repository\Adapter\AdapterInterface>
+     * @return \PhpOption\Option<self>
      */
     public static function create()
     {
-        /** @var \PhpOption\Option<AdapterInterface> */
         return Some::create(new self());
     }
 

--- a/src/Repository/Adapter/PutenvAdapter.php
+++ b/src/Repository/Adapter/PutenvAdapter.php
@@ -23,12 +23,11 @@ final class PutenvAdapter implements AdapterInterface
     /**
      * Create a new instance of the adapter, if it is available.
      *
-     * @return \PhpOption\Option<\Dotenv\Repository\Adapter\AdapterInterface>
+     * @return \PhpOption\Option<self>
      */
     public static function create()
     {
         if (self::isSupported()) {
-            /** @var \PhpOption\Option<AdapterInterface> */
             return Some::create(new self());
         }
 

--- a/src/Repository/Adapter/ServerConstAdapter.php
+++ b/src/Repository/Adapter/ServerConstAdapter.php
@@ -22,11 +22,10 @@ final class ServerConstAdapter implements AdapterInterface
     /**
      * Create a new instance of the adapter, if it is available.
      *
-     * @return \PhpOption\Option<\Dotenv\Repository\Adapter\AdapterInterface>
+     * @return \PhpOption\Option<self>
      */
     public static function create()
     {
-        /** @var \PhpOption\Option<AdapterInterface> */
         return Some::create(new self());
     }
 

--- a/src/Repository/RepositoryBuilder.php
+++ b/src/Repository/RepositoryBuilder.php
@@ -132,7 +132,7 @@ final class RepositoryBuilder
      * Accepts either a reader instance, or a class-string for an adapter. If
      * the adapter is not supported, then we silently skip adding it.
      *
-     * @param \Dotenv\Repository\Adapter\ReaderInterface|string $reader
+     * @param \Dotenv\Repository\Adapter\ReaderInterface|class-string<\Dotenv\Repository\Adapter\AdapterInterface> $reader
      *
      * @throws \InvalidArgumentException
      *
@@ -165,7 +165,7 @@ final class RepositoryBuilder
      * Accepts either a writer instance, or a class-string for an adapter. If
      * the adapter is not supported, then we silently skip adding it.
      *
-     * @param \Dotenv\Repository\Adapter\WriterInterface|string $writer
+     * @param \Dotenv\Repository\Adapter\WriterInterface|class-string<\Dotenv\Repository\Adapter\AdapterInterface> $writer
      *
      * @throws \InvalidArgumentException
      *
@@ -199,7 +199,7 @@ final class RepositoryBuilder
      * the adapter is not supported, then we silently skip adding it. We will
      * add the adapter as both a reader and a writer.
      *
-     * @param \Dotenv\Repository\Adapter\WriterInterface|string $adapter
+     * @param \Dotenv\Repository\Adapter\AdapterInterface|class-string<\Dotenv\Repository\Adapter\AdapterInterface> $adapter
      *
      * @throws \InvalidArgumentException
      *

--- a/src/Util/Regex.php
+++ b/src/Util/Regex.php
@@ -43,7 +43,7 @@ final class Regex
      * @param string $pattern
      * @param string $subject
      *
-     * @return \GrahamCampbell\ResultType\Result<int, string>
+     * @return \GrahamCampbell\ResultType\Result<int<0, max>, string>
      */
     public static function occurrences(string $pattern, string $subject)
     {

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -69,11 +69,11 @@ final class Str
      * @param string $haystack
      * @param string $needle
      *
-     * @return \PhpOption\Option<int>
+     * @return \PhpOption\Option<int<0, max>>
      */
     public static function pos(string $haystack, string $needle)
     {
-        /** @var \PhpOption\Option<int> */
+        /** @var \PhpOption\Option<int<0, max>> */
         return Option::fromValue(\mb_strpos($haystack, $needle, 0, 'UTF-8'), false);
     }
 


### PR DESCRIPTION
With the covariant option and result types in place, several annotations can now say precisely
what the code does. The five concrete adapters declare create() as returning an option of the
adapter itself rather than of the interface, which removes the widening casts inside them and
gives callers the concrete type. The repository builder's reader, writer and adapter parameters
now document the actual acceptance, an instance of the respective interface or a class-string of
an adapter, which matches the runtime guards exactly and lets the builder closures type-check
without laundering. The string and regex helpers declare the non-negative integer ranges they
actually produce, correcting a wrong-shaped cast in Str::pos. None of this changes behaviour, and
code typed against the old signatures only ever sees narrower types. The phpstan baseline shrinks
from sixteen entries to five as a byproduct.
