### PR TITLE
Stop comments from starting multiline values

### DIFF
--- a/src/Parser/Lines.php
+++ b/src/Parser/Lines.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Dotenv\Parser;
 
 use Dotenv\Util\Regex;
-use Dotenv\Util\Str;
 
 final class Lines
 {
@@ -87,9 +86,19 @@ final class Lines
      */
     private static function looksLikeMultilineStart(string $line)
     {
-        return Str::pos($line, '="')->map(static function () use ($line) {
-            return self::looksLikeMultilineStop($line, true) === false;
-        })->getOrElse(false);
+        $pos = \strpos($line, '="');
+
+        if ($pos === false) {
+            return false;
+        }
+
+        $hash = \strpos($line, '#');
+
+        if ($hash !== false && $hash < $pos) {
+            return false;
+        }
+
+        return self::looksLikeMultilineStop($line, true) === false;
     }
 
     /**

--- a/tests/Dotenv/DotenvTest.php
+++ b/tests/Dotenv/DotenvTest.php
@@ -434,6 +434,22 @@ final class DotenvTest extends TestCase
         self::assertSame(['A' => '1'], Dotenv::parse("   # c\nA=1"));
     }
 
+    public function testDotenvParseCommentContainingQuoteStart()
+    {
+        self::assertSame(
+            ['A' => '1', 'B' => '2'],
+            Dotenv::parse("A=1 # example=\"unterminated\nB=2")
+        );
+    }
+
+    public function testDotenvParseMultilineContainingHash()
+    {
+        self::assertSame(
+            ['A' => "one # data\ntwo", 'B' => '2'],
+            Dotenv::parse("A=\"one # data\ntwo\"\nB=2")
+        );
+    }
+
     public function testDotenvParseEmptyCase()
     {
         $output = Dotenv::parse('');


### PR DESCRIPTION
Comment recognition happens only after multiline detection, and the multiline heuristic searches the whole physical line for a quote start, so a comment containing the characters =" opened a phantom multiline buffer: every following line was silently swallowed until a stray closing quote arrived or the buffer was discarded at end of file, making unrelated later assignments vanish without an error, including for realistic inputs like a URL value followed by a comment mentioning a quoted example. The multiline start is now ignored when a hash appears earlier in the line than the quote start, so comments can no longer open multiline values, while genuine multiline values, including ones whose opening line contains a hash inside the quotes, are unchanged. The only behaviour change on previously accepted input is that a stray quote line following such a comment now fails name validation loudly instead of being silently dropped with its neighbours. This is stacked on #608.
