### PR TITLE
fix: don't silently drop an unterminated multiline value

### DIFF
--- a/src/Parser/Lines.php
+++ b/src/Parser/Lines.php
@@ -43,6 +43,14 @@ final class Lines
             }
         }
 
+        // If the input ends while still inside a multiline value, the value
+        // was never closed. Emit the buffered content as a final entry
+        // instead of silently discarding it, so the parser reports the same
+        // missing-closing-quote error the single-quoted case already does.
+        if ($multiline && $multilineBuffer !== []) {
+            $output[] = \implode("\n", $multilineBuffer);
+        }
+
         return $output;
     }
 

--- a/tests/Dotenv/Parser/LinesTest.php
+++ b/tests/Dotenv/Parser/LinesTest.php
@@ -50,4 +50,20 @@ final class LinesTest extends TestCase
 
         self::assertSame($expected, Lines::process($result->success()->get()));
     }
+
+    public function testProcessUnterminatedMultilineIsEmittedNotDropped()
+    {
+        $result = Regex::split("/(\r\n|\n|\r)/", "FOO=\"bar");
+        self::assertTrue($result->success()->isDefined());
+
+        self::assertSame(['FOO="bar'], Lines::process($result->success()->get()));
+    }
+
+    public function testProcessUnterminatedMultilineDoesNotSwallowFollowingLines()
+    {
+        $result = Regex::split("/(\r\n|\n|\r)/", "A=\"oops\nB=keep");
+        self::assertTrue($result->success()->isDefined());
+
+        self::assertSame(["A=\"oops\nB=keep"], Lines::process($result->success()->get()));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #610

When a double-quoted value was left unterminated at the end of the input, `Lines::process()` discarded the buffered content instead of emitting it, so the whole entry — and every line after it, since they were still being buffered as part of the same unclosed multiline value — vanished with no error:

```php
Dotenv::parse('FOO="bar');            // returns [] — no exception
Dotenv::parse("A=\"oops\nB=keep");    // returns [] — B is silently dropped too
```

This was inconsistent with the single-quoted case, which already reports a missing closing quote — single-quoted values aren't treated as multiline at all, so an unterminated one reaches `EntryParser` directly and fails loudly:

```php
Dotenv::parse("FOO='bar");            // throws "a missing closing quote"
```

## Fix

Emit the still-open buffer as a final output entry instead of discarding it when the input ends mid-multiline-value. It then reaches `EntryParser` exactly like a normal entry, and the lexer ends in one of the `REJECT_STATES` at EOF, so it raises the same `"a missing closing quote"` error the single-quoted path already produces. A properly closed multiline value is unaffected, since the buffer is already flushed to `$output` by the time the loop ends.

As noted in the issue, this is a behaviour change — input that previously parsed to an empty or truncated array now throws — so it targets `master` rather than a `4.x` patch release. The prior behaviour was silent data loss, which is the stronger correctness concern.

## Test plan

- Added two cases to `tests/Dotenv/Parser/LinesTest.php`: an unterminated double-quoted value is emitted (not dropped), and a following line is no longer silently swallowed.
- Verified both new tests fail against the pre-fix code with the exact reported symptom (`Lines::process()` returning `[]`), and pass with the fix.
- Verified a properly closed multiline value, a normal single-line value, and empty input are all unaffected.
- Ran the full test suite (`vendor/bin/phpunit`): 282 tests, all passing (280 pre-existing + 2 new).
- `vendor/bin/phpstan analyze` (configured scope: `src`, level `max`): no errors.